### PR TITLE
fix: fix clang-tidy errors

### DIFF
--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -80,13 +80,12 @@ jobs:
             **/*.cpp
             **/*.hpp
 
-      # TODO(youtalk): Comment in after fixing clang-tidy error
-      # - name: Run clang-tidy
-      #   if: ${{ steps.get-modified-files.outputs.all_changed_files != '' }}
-      #   uses: autowarefoundation/autoware-github-actions/clang-tidy@v1
-      #   with:
-      #     rosdistro: humble
-      #     target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
-      #     target-files: ${{ steps.get-modified-files.outputs.all_changed_files }}
-      #     clang-tidy-config-url: https://raw.githubusercontent.com/autowarefoundation/autoware/main/.clang-tidy
-      #     build-depends-repos: build_depends.repos
+      - name: Run clang-tidy
+        if: ${{ steps.get-modified-files.outputs.all_changed_files != '' }}
+        uses: autowarefoundation/autoware-github-actions/clang-tidy@v1
+        with:
+          rosdistro: humble
+          target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
+          target-files: ${{ steps.get-modified-files.outputs.all_changed_files }}
+          clang-tidy-config-url: https://raw.githubusercontent.com/autowarefoundation/autoware/main/.clang-tidy
+          build-depends-repos: build_depends.repos

--- a/lanelet2_extension_python/src/projection.cpp
+++ b/lanelet2_extension_python/src/projection.cpp
@@ -31,12 +31,14 @@ BOOST_PYTHON_MODULE(_lanelet2_extension_python_boost_python_projection)
 
   bp::class_<
     lanelet::projection::MGRSProjector, std::shared_ptr<lanelet::projection::MGRSProjector>,
-    bp::bases<lanelet::Projector>>("MGRSProjector", bp::init<lanelet::Origin>("origin"));
+    bp::bases<lanelet::Projector>>
+    mgrs_projector("MGRSProjector", bp::init<lanelet::Origin>("origin"));
   bp::class_<
     lanelet::projection::TransverseMercatorProjector,
     std::shared_ptr<lanelet::projection::TransverseMercatorProjector>,
-    bp::bases<lanelet::Projector>>(
-    "TransverseMercatorProjector", bp::init<lanelet::Origin>("origin"));
+    bp::bases<lanelet::Projector>>
+    transverse_mercator_projector(
+      "TransverseMercatorProjector", bp::init<lanelet::Origin>("origin"));
 }
 
 // NOLINTEND(readability-identifier-naming)

--- a/lanelet2_extension_python/src/utility.cpp
+++ b/lanelet2_extension_python/src/utility.cpp
@@ -45,9 +45,8 @@ lanelet::Optional<lanelet::ConstPolygon3d> lineStringWithWidthToPolygon(
   lanelet::ConstPolygon3d poly{};
   if (lanelet::utils::lineStringWithWidthToPolygon(linestring, &poly)) {
     return poly;
-  } else {
-    return {};
   }
+  return {};
 }
 
 lanelet::Optional<lanelet::ConstPolygon3d> lineStringToPolygon(
@@ -56,9 +55,8 @@ lanelet::Optional<lanelet::ConstPolygon3d> lineStringToPolygon(
   lanelet::ConstPolygon3d poly{};
   if (lanelet::utils::lineStringToPolygon(linestring, &poly)) {
     return poly;
-  } else {
-    return {};
   }
+  return {};
 }
 
 lanelet::ArcCoordinates getArcCoordinates(
@@ -180,9 +178,8 @@ lanelet::Optional<lanelet::ConstLanelet> getLinkedLanelet(
   if (lanelet::utils::query::getLinkedLanelet(
         parking_space, all_road_lanelets, all_parking_lots, &linked_lanelet)) {
     return linked_lanelet;
-  } else {
-    return {};
   }
+  return {};
 }
 
 lanelet::Optional<lanelet::ConstLanelet> getLinkedLanelet(
@@ -192,9 +189,8 @@ lanelet::Optional<lanelet::ConstLanelet> getLinkedLanelet(
   lanelet::ConstLanelet linked_lanelet;
   if (lanelet::utils::query::getLinkedLanelet(parking_space, lanelet_map_ptr, &linked_lanelet)) {
     return linked_lanelet;
-  } else {
-    return {};
   }
+  return {};
 }
 
 lanelet::Optional<lanelet::ConstPolygon3d> getLinkedParkingLot(
@@ -203,9 +199,8 @@ lanelet::Optional<lanelet::ConstPolygon3d> getLinkedParkingLot(
   lanelet::ConstPolygon3d linked_parking_lot;
   if (lanelet::utils::query::getLinkedParkingLot(lanelet, all_parking_lots, &linked_parking_lot)) {
     return linked_parking_lot;
-  } else {
-    return {};
   }
+  return {};
 }
 
 lanelet::Optional<lanelet::ConstPolygon3d> getLinkedParkingLot(
@@ -215,9 +210,8 @@ lanelet::Optional<lanelet::ConstPolygon3d> getLinkedParkingLot(
   if (lanelet::utils::query::getLinkedParkingLot(
         current_position, all_parking_lots, &linked_parking_lot)) {
     return linked_parking_lot;
-  } else {
-    return {};
   }
+  return {};
 }
 
 lanelet::Optional<lanelet::ConstPolygon3d> getLinkedParkingLot(
@@ -228,9 +222,8 @@ lanelet::Optional<lanelet::ConstPolygon3d> getLinkedParkingLot(
   if (lanelet::utils::query::getLinkedParkingLot(
         parking_space, all_parking_lots, &linked_parking_lot)) {
     return linked_parking_lot;
-  } else {
-    return {};
   }
+  return {};
 }
 
 lanelet::ConstLanelets getLaneletsWithinRange_point(
@@ -299,9 +292,8 @@ lanelet::Optional<lanelet::ConstLanelet> getClosestLanelet(
   lanelet::ConstLanelet closest_lanelet{};
   if (lanelet::utils::query::getClosestLanelet(lanelets, pose, &closest_lanelet)) {
     return closest_lanelet;
-  } else {
-    return {};
   }
+  return {};
 }
 
 lanelet::Optional<lanelet::ConstLanelet> getClosestLaneletWithConstrains(
@@ -323,9 +315,8 @@ lanelet::Optional<lanelet::ConstLanelet> getClosestLaneletWithConstrains(
   if (lanelet::utils::query::getClosestLaneletWithConstrains(
         lanelets, pose, &closest_lanelet, dist_threshold, yaw_threshold)) {
     return closest_lanelet;
-  } else {
-    return {};
   }
+  return {};
 }
 
 lanelet::ConstLanelets getCurrentLanelets_point(

--- a/lanelet2_extension_python/src/utility.cpp
+++ b/lanelet2_extension_python/src/utility.cpp
@@ -359,6 +359,7 @@ lanelet::ConstLanelets getCurrentLanelets_pose(
 
 // for handling functions with default arguments
 /// utilities.cpp
+// NOLINTBEGIN(google-explicit-constructor)
 BOOST_PYTHON_FUNCTION_OVERLOADS(
   generateFineCenterline_overload, lanelet::utils::generateFineCenterline, 1, 2)
 BOOST_PYTHON_FUNCTION_OVERLOADS(
@@ -378,6 +379,7 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(
   getClosestLaneletWithConstrains_overload, ::getClosestLaneletWithConstrains, 2, 4)
 BOOST_PYTHON_FUNCTION_OVERLOADS(
   getPrecedingLaneletSequences_overload, lanelet::utils::query::getPrecedingLaneletSequences, 3, 4)
+// NOLINTEND(google-explicit-constructor)
 
 BOOST_PYTHON_MODULE(_lanelet2_extension_python_boost_python_utility)
 {

--- a/lanelet2_extension_python/src/utility.cpp
+++ b/lanelet2_extension_python/src/utility.cpp
@@ -67,7 +67,8 @@ lanelet::ArcCoordinates getArcCoordinates(
   serialized_msg.reserve(message_header_length + pose_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = pose_byte.size();
   for (size_t i = 0; i < pose_byte.size(); ++i) {
-    serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];  // NOLINT
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];
   }
   geometry_msgs::msg::Pose pose;
   static rclcpp::Serialization<geometry_msgs::msg::Pose> serializer;
@@ -82,7 +83,8 @@ double getLaneletAngle(const lanelet::ConstLanelet & lanelet, const std::string 
   serialized_msg.reserve(message_header_length + point_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = point_byte.size();
   for (size_t i = 0; i < point_byte.size(); ++i) {
-    serialized_msg.get_rcl_serialized_message().buffer[i] = point_byte[i];  // NOLINT
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    serialized_msg.get_rcl_serialized_message().buffer[i] = point_byte[i];
   }
   geometry_msgs::msg::Point point;
   static rclcpp::Serialization<geometry_msgs::msg::Point> serializer;
@@ -98,7 +100,8 @@ bool isInLanelet(
   serialized_msg.reserve(message_header_length + pose_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = pose_byte.size();
   for (size_t i = 0; i < pose_byte.size(); ++i) {
-    serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];  // NOLINT
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];
   }
   geometry_msgs::msg::Pose pose;
   static rclcpp::Serialization<geometry_msgs::msg::Pose> serializer;
@@ -114,7 +117,8 @@ std::vector<double> getClosestCenterPose(
   serialized_point_msg.reserve(message_header_length + search_point_byte.size());
   serialized_point_msg.get_rcl_serialized_message().buffer_length = search_point_byte.size();
   for (size_t i = 0; i < search_point_byte.size(); ++i) {
-    serialized_point_msg.get_rcl_serialized_message().buffer[i] = search_point_byte[i];  // NOLINT
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    serialized_point_msg.get_rcl_serialized_message().buffer[i] = search_point_byte[i];
   }
   geometry_msgs::msg::Point search_point;
   static rclcpp::Serialization<geometry_msgs::msg::Point> serializer_point;
@@ -135,7 +139,8 @@ double getLateralDistanceToCenterline(
   serialized_msg.reserve(message_header_length + pose_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = pose_byte.size();
   for (size_t i = 0; i < pose_byte.size(); ++i) {
-    serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];  // NOLINT
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];
   }
   geometry_msgs::msg::Pose pose;
   static rclcpp::Serialization<geometry_msgs::msg::Pose> serializer;
@@ -151,7 +156,8 @@ double getLateralDistanceToClosestLanelet(
   serialized_msg.reserve(message_header_length + pose_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = pose_byte.size();
   for (size_t i = 0; i < pose_byte.size(); ++i) {
-    serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];  // NOLINT
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];
   }
   geometry_msgs::msg::Pose pose;
   static rclcpp::Serialization<geometry_msgs::msg::Pose> serializer;
@@ -234,7 +240,8 @@ lanelet::ConstLanelets getLaneletsWithinRange_point(
   serialized_msg.reserve(message_header_length + point_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = point_byte.size();
   for (size_t i = 0; i < point_byte.size(); ++i) {
-    serialized_msg.get_rcl_serialized_message().buffer[i] = point_byte[i];  // NOLINT
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    serialized_msg.get_rcl_serialized_message().buffer[i] = point_byte[i];
   }
   geometry_msgs::msg::Point point;
   static rclcpp::Serialization<geometry_msgs::msg::Point> serializer;
@@ -251,7 +258,8 @@ lanelet::ConstLanelets getLaneChangeableNeighbors_point(
   serialized_msg.reserve(message_header_length + point_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = point_byte.size();
   for (size_t i = 0; i < point_byte.size(); ++i) {
-    serialized_msg.get_rcl_serialized_message().buffer[i] = point_byte[i];  // NOLINT
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    serialized_msg.get_rcl_serialized_message().buffer[i] = point_byte[i];
   }
   geometry_msgs::msg::Point point;
   static rclcpp::Serialization<geometry_msgs::msg::Point> serializer;
@@ -268,7 +276,8 @@ lanelet::ConstLanelets getAllNeighbors_point(
   serialized_msg.reserve(message_header_length + point_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = point_byte.size();
   for (size_t i = 0; i < point_byte.size(); ++i) {
-    serialized_msg.get_rcl_serialized_message().buffer[i] = point_byte[i];  // NOLINT
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    serialized_msg.get_rcl_serialized_message().buffer[i] = point_byte[i];
   }
   geometry_msgs::msg::Point point;
   static rclcpp::Serialization<geometry_msgs::msg::Point> serializer;
@@ -284,7 +293,8 @@ lanelet::Optional<lanelet::ConstLanelet> getClosestLanelet(
   serialized_msg.reserve(message_header_length + pose_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = pose_byte.size();
   for (size_t i = 0; i < pose_byte.size(); ++i) {
-    serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];  // NOLINT
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];
   }
   geometry_msgs::msg::Pose pose;
   static rclcpp::Serialization<geometry_msgs::msg::Pose> serializer;
@@ -306,7 +316,8 @@ lanelet::Optional<lanelet::ConstLanelet> getClosestLaneletWithConstrains(
   serialized_msg.reserve(message_header_length + pose_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = pose_byte.size();
   for (size_t i = 0; i < pose_byte.size(); ++i) {
-    serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];  // NOLINT
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];
   }
   geometry_msgs::msg::Pose pose;
   static rclcpp::Serialization<geometry_msgs::msg::Pose> serializer;
@@ -327,7 +338,8 @@ lanelet::ConstLanelets getCurrentLanelets_point(
   serialized_msg.reserve(message_header_length + point_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = point_byte.size();
   for (size_t i = 0; i < point_byte.size(); ++i) {
-    serialized_msg.get_rcl_serialized_message().buffer[i] = point_byte[i];  // NOLINT
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    serialized_msg.get_rcl_serialized_message().buffer[i] = point_byte[i];
   }
   geometry_msgs::msg::Point point;
   static rclcpp::Serialization<geometry_msgs::msg::Point> serializer;
@@ -345,7 +357,8 @@ lanelet::ConstLanelets getCurrentLanelets_pose(
   serialized_msg.reserve(message_header_length + pose_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = pose_byte.size();
   for (size_t i = 0; i < pose_byte.size(); ++i) {
-    serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];  // NOLINT
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];
   }
   geometry_msgs::msg::Pose pose;
   static rclcpp::Serialization<geometry_msgs::msg::Pose> serializer;

--- a/lanelet2_extension_python/src/utility.cpp
+++ b/lanelet2_extension_python/src/utility.cpp
@@ -67,7 +67,7 @@ lanelet::ArcCoordinates getArcCoordinates(
   serialized_msg.reserve(message_header_length + pose_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = pose_byte.size();
   for (size_t i = 0; i < pose_byte.size(); ++i) {
-    serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];
+    serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];  // NOLINT
   }
   geometry_msgs::msg::Pose pose;
   static rclcpp::Serialization<geometry_msgs::msg::Pose> serializer;
@@ -82,7 +82,7 @@ double getLaneletAngle(const lanelet::ConstLanelet & lanelet, const std::string 
   serialized_msg.reserve(message_header_length + point_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = point_byte.size();
   for (size_t i = 0; i < point_byte.size(); ++i) {
-    serialized_msg.get_rcl_serialized_message().buffer[i] = point_byte[i];
+    serialized_msg.get_rcl_serialized_message().buffer[i] = point_byte[i];  // NOLINT
   }
   geometry_msgs::msg::Point point;
   static rclcpp::Serialization<geometry_msgs::msg::Point> serializer;
@@ -98,7 +98,7 @@ bool isInLanelet(
   serialized_msg.reserve(message_header_length + pose_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = pose_byte.size();
   for (size_t i = 0; i < pose_byte.size(); ++i) {
-    serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];
+    serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];  // NOLINT
   }
   geometry_msgs::msg::Pose pose;
   static rclcpp::Serialization<geometry_msgs::msg::Pose> serializer;
@@ -114,7 +114,7 @@ std::vector<double> getClosestCenterPose(
   serialized_point_msg.reserve(message_header_length + search_point_byte.size());
   serialized_point_msg.get_rcl_serialized_message().buffer_length = search_point_byte.size();
   for (size_t i = 0; i < search_point_byte.size(); ++i) {
-    serialized_point_msg.get_rcl_serialized_message().buffer[i] = search_point_byte[i];
+    serialized_point_msg.get_rcl_serialized_message().buffer[i] = search_point_byte[i];  // NOLINT
   }
   geometry_msgs::msg::Point search_point;
   static rclcpp::Serialization<geometry_msgs::msg::Point> serializer_point;
@@ -135,7 +135,7 @@ double getLateralDistanceToCenterline(
   serialized_msg.reserve(message_header_length + pose_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = pose_byte.size();
   for (size_t i = 0; i < pose_byte.size(); ++i) {
-    serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];
+    serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];  // NOLINT
   }
   geometry_msgs::msg::Pose pose;
   static rclcpp::Serialization<geometry_msgs::msg::Pose> serializer;
@@ -151,7 +151,7 @@ double getLateralDistanceToClosestLanelet(
   serialized_msg.reserve(message_header_length + pose_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = pose_byte.size();
   for (size_t i = 0; i < pose_byte.size(); ++i) {
-    serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];
+    serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];  // NOLINT
   }
   geometry_msgs::msg::Pose pose;
   static rclcpp::Serialization<geometry_msgs::msg::Pose> serializer;
@@ -234,7 +234,7 @@ lanelet::ConstLanelets getLaneletsWithinRange_point(
   serialized_msg.reserve(message_header_length + point_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = point_byte.size();
   for (size_t i = 0; i < point_byte.size(); ++i) {
-    serialized_msg.get_rcl_serialized_message().buffer[i] = point_byte[i];
+    serialized_msg.get_rcl_serialized_message().buffer[i] = point_byte[i];  // NOLINT
   }
   geometry_msgs::msg::Point point;
   static rclcpp::Serialization<geometry_msgs::msg::Point> serializer;
@@ -251,7 +251,7 @@ lanelet::ConstLanelets getLaneChangeableNeighbors_point(
   serialized_msg.reserve(message_header_length + point_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = point_byte.size();
   for (size_t i = 0; i < point_byte.size(); ++i) {
-    serialized_msg.get_rcl_serialized_message().buffer[i] = point_byte[i];
+    serialized_msg.get_rcl_serialized_message().buffer[i] = point_byte[i];  // NOLINT
   }
   geometry_msgs::msg::Point point;
   static rclcpp::Serialization<geometry_msgs::msg::Point> serializer;
@@ -268,7 +268,7 @@ lanelet::ConstLanelets getAllNeighbors_point(
   serialized_msg.reserve(message_header_length + point_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = point_byte.size();
   for (size_t i = 0; i < point_byte.size(); ++i) {
-    serialized_msg.get_rcl_serialized_message().buffer[i] = point_byte[i];
+    serialized_msg.get_rcl_serialized_message().buffer[i] = point_byte[i];  // NOLINT
   }
   geometry_msgs::msg::Point point;
   static rclcpp::Serialization<geometry_msgs::msg::Point> serializer;
@@ -284,7 +284,7 @@ lanelet::Optional<lanelet::ConstLanelet> getClosestLanelet(
   serialized_msg.reserve(message_header_length + pose_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = pose_byte.size();
   for (size_t i = 0; i < pose_byte.size(); ++i) {
-    serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];
+    serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];  // NOLINT
   }
   geometry_msgs::msg::Pose pose;
   static rclcpp::Serialization<geometry_msgs::msg::Pose> serializer;
@@ -306,7 +306,7 @@ lanelet::Optional<lanelet::ConstLanelet> getClosestLaneletWithConstrains(
   serialized_msg.reserve(message_header_length + pose_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = pose_byte.size();
   for (size_t i = 0; i < pose_byte.size(); ++i) {
-    serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];
+    serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];  // NOLINT
   }
   geometry_msgs::msg::Pose pose;
   static rclcpp::Serialization<geometry_msgs::msg::Pose> serializer;
@@ -327,7 +327,7 @@ lanelet::ConstLanelets getCurrentLanelets_point(
   serialized_msg.reserve(message_header_length + point_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = point_byte.size();
   for (size_t i = 0; i < point_byte.size(); ++i) {
-    serialized_msg.get_rcl_serialized_message().buffer[i] = point_byte[i];
+    serialized_msg.get_rcl_serialized_message().buffer[i] = point_byte[i];  // NOLINT
   }
   geometry_msgs::msg::Point point;
   static rclcpp::Serialization<geometry_msgs::msg::Point> serializer;
@@ -345,7 +345,7 @@ lanelet::ConstLanelets getCurrentLanelets_pose(
   serialized_msg.reserve(message_header_length + pose_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = pose_byte.size();
   for (size_t i = 0; i < pose_byte.size(); ++i) {
-    serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];
+    serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];  // NOLINT
   }
   geometry_msgs::msg::Pose pose;
   static rclcpp::Serialization<geometry_msgs::msg::Pose> serializer;


### PR DESCRIPTION
- [x] #2 

This PR has fixed [the clang-tidy errors](https://github.com/autowarefoundation/autoware_lanelet2_extension/pull/2#issuecomment-2089167474).