### PR TITLE
feat: `autoware_msgs` migration

### DIFF
--- a/autoware_lanelet2_extension/README.md
+++ b/autoware_lanelet2_extension/README.md
@@ -54,7 +54,7 @@ Autoware intersection module requires the information on which lanes can be igno
 This contains functions to convert lanelet map objects into ROS messages.
 Currently it contains following conversions:
 
-- lanelet::LaneletMapPtr to/from autoware_auto_mapping_msgs::msg::HADMapBin
+- lanelet::LaneletMapPtr to/from autoware_map_msgs::msg::LaneletMapBin
 - lanelet::Point3d to geometry_msgs::Point
 - lanelet::Point2d to geometry_msgs::Point
 - lanelet::BasicPoint3d to geometry_msgs::Point

--- a/autoware_lanelet2_extension/include/autoware_lanelet2_extension/localization/landmark.hpp
+++ b/autoware_lanelet2_extension/include/autoware_lanelet2_extension/localization/landmark.hpp
@@ -15,7 +15,7 @@
 #ifndef LANELET2_EXTENSION__LOCALIZATION__LANDMARK_HPP_
 #define LANELET2_EXTENSION__LOCALIZATION__LANDMARK_HPP_
 
-#include "autoware_auto_mapping_msgs/msg/had_map_bin.hpp"
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 
 #include <lanelet2_core/primitives/Polygon.h>
 
@@ -28,7 +28,7 @@ namespace lanelet::localization
 {
 
 std::vector<lanelet::Polygon3d> parseLandmarkPolygons(
-  const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr & msg,
+  const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr & msg,
   const std::string & target_subtype);
 
 }  // namespace lanelet::localization

--- a/autoware_lanelet2_extension/include/autoware_lanelet2_extension/utility/message_conversion.hpp
+++ b/autoware_lanelet2_extension/include/autoware_lanelet2_extension/utility/message_conversion.hpp
@@ -19,7 +19,7 @@
 
 // NOLINTBEGIN(readability-identifier-naming)
 
-#include <autoware_auto_mapping_msgs/msg/had_map_bin.hpp>
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/point32.hpp>
 #include <geometry_msgs/msg/polygon.hpp>
@@ -36,7 +36,7 @@ namespace lanelet::utils::conversion
  * @param map [lanelet map data]
  * @param msg [converted ROS message. Only "data" field is filled]
  */
-void toBinMsg(const lanelet::LaneletMapPtr & map, autoware_auto_mapping_msgs::msg::HADMapBin * msg);
+void toBinMsg(const lanelet::LaneletMapPtr & map, autoware_map_msgs::msg::LaneletMapBin * msg);
 
 /**
  * [fromBinMsg converts ROS message into lanelet2 data. Similar implementation
@@ -44,9 +44,9 @@ void toBinMsg(const lanelet::LaneletMapPtr & map, autoware_auto_mapping_msgs::ms
  * @param msg [ROS message for lanelet map]
  * @param map [Converted lanelet2 data]
  */
-void fromBinMsg(const autoware_auto_mapping_msgs::msg::HADMapBin & msg, lanelet::LaneletMapPtr map);
+void fromBinMsg(const autoware_map_msgs::msg::LaneletMapBin & msg, lanelet::LaneletMapPtr map);
 void fromBinMsg(
-  const autoware_auto_mapping_msgs::msg::HADMapBin & msg, lanelet::LaneletMapPtr map,
+  const autoware_map_msgs::msg::LaneletMapBin & msg, lanelet::LaneletMapPtr map,
   lanelet::traffic_rules::TrafficRulesPtr * traffic_rules,
   lanelet::routing::RoutingGraphPtr * routing_graph);
 

--- a/autoware_lanelet2_extension/lib/landmark.cpp
+++ b/autoware_lanelet2_extension/lib/landmark.cpp
@@ -24,7 +24,7 @@ namespace lanelet::localization
 {
 
 std::vector<lanelet::Polygon3d> parseLandmarkPolygons(
-  const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr & msg,
+  const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr & msg,
   const std::string & target_subtype)
 {
   lanelet::LaneletMapPtr lanelet_map_ptr{std::make_shared<lanelet::LaneletMap>()};

--- a/autoware_lanelet2_extension/lib/message_conversion.cpp
+++ b/autoware_lanelet2_extension/lib/message_conversion.cpp
@@ -39,7 +39,7 @@
 
 namespace lanelet::utils::conversion
 {
-void toBinMsg(const lanelet::LaneletMapPtr & map, autoware_auto_mapping_msgs::msg::HADMapBin * msg)
+void toBinMsg(const lanelet::LaneletMapPtr & map, autoware_map_msgs::msg::LaneletMapBin * msg)
 {
   if (msg == nullptr) {
     std::cerr << __FUNCTION__ << "msg is null pointer!";
@@ -58,7 +58,7 @@ void toBinMsg(const lanelet::LaneletMapPtr & map, autoware_auto_mapping_msgs::ms
   msg->data.assign(data_str.begin(), data_str.end());
 }
 
-void fromBinMsg(const autoware_auto_mapping_msgs::msg::HADMapBin & msg, lanelet::LaneletMapPtr map)
+void fromBinMsg(const autoware_map_msgs::msg::LaneletMapBin & msg, lanelet::LaneletMapPtr map)
 {
   if (!map) {
     std::cerr << __FUNCTION__ << ": map is null pointer!";
@@ -79,7 +79,7 @@ void fromBinMsg(const autoware_auto_mapping_msgs::msg::HADMapBin & msg, lanelet:
 }
 
 void fromBinMsg(
-  const autoware_auto_mapping_msgs::msg::HADMapBin & msg, lanelet::LaneletMapPtr map,
+  const autoware_map_msgs::msg::LaneletMapBin & msg, lanelet::LaneletMapPtr map,
   lanelet::traffic_rules::TrafficRulesPtr * traffic_rules,
   lanelet::routing::RoutingGraphPtr * routing_graph)
 {

--- a/autoware_lanelet2_extension/package.xml
+++ b/autoware_lanelet2_extension/package.xml
@@ -15,7 +15,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_map_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_utils</depend>

--- a/autoware_lanelet2_extension/package.xml
+++ b/autoware_lanelet2_extension/package.xml
@@ -15,8 +15,8 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
+  <depend>autoware_map_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_utils</depend>
   <depend>geographiclib</depend>

--- a/autoware_lanelet2_extension/test/src/test_message_conversion.cpp
+++ b/autoware_lanelet2_extension/test/src/test_message_conversion.cpp
@@ -67,7 +67,7 @@ private:
 
 TEST_F(TestSuite, BinMsgConversion)  // NOLINT for gtest
 {
-  autoware_auto_mapping_msgs::msg::HADMapBin bin_msg;
+  autoware_map_msgs::msg::LaneletMapBin bin_msg;
   lanelet::LaneletMapPtr regenerated_map(new lanelet::LaneletMap);
 
   lanelet::utils::conversion::toBinMsg(single_lanelet_map_ptr, &bin_msg);

--- a/autoware_lanelet2_extension/test/src/test_route_checker.cpp
+++ b/autoware_lanelet2_extension/test/src/test_route_checker.cpp
@@ -17,7 +17,7 @@
 #include "autoware_lanelet2_extension/utility/message_conversion.hpp"
 #include "autoware_lanelet2_extension/utility/route_checker.hpp"
 
-#include <autoware_auto_mapping_msgs/msg/had_map_bin.hpp>
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
 
 #include <gtest/gtest.h>
@@ -74,7 +74,7 @@ private:
 
 TEST_F(TestSuite, isRouteValid)  // NOLINT for gtest
 {
-  autoware_auto_mapping_msgs::msg::HADMapBin bin_msg;
+  autoware_map_msgs::msg::LaneletMapBin bin_msg;
 
   const auto route_ptr1 =
     std::make_shared<autoware_planning_msgs::msg::LaneletRoute>(sample_route1);

--- a/build_depends.repos
+++ b/build_depends.repos
@@ -1,8 +1,4 @@
 repositories:
-  autoware_auto_msgs:
-    type: git
-    url: https://github.com/tier4/autoware_auto_msgs.git
-    version: tier4/main
   autoware_cmake:
     type: git
     url: https://github.com/autowarefoundation/autoware_cmake.git


### PR DESCRIPTION
## Description

This PR has made the transition from `autoware_auto_msgs` to `autoware_msgs`.
The commit history is originally from https://github.com/autowarefoundation/autoware_common/compare/main...autoware_msg

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
