### PR TITLE
chore(ci): fix cpplint errors from pre-commit ci

### DIFF
--- a/autoware_lanelet2_extension_python/src/utility.cpp
+++ b/autoware_lanelet2_extension_python/src/utility.cpp
@@ -67,8 +67,9 @@ lanelet::ArcCoordinates getArcCoordinates(
   serialized_msg.reserve(message_header_length + pose_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = pose_byte.size();
   for (size_t i = 0; i < pose_byte.size(); ++i) {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];
+    // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   }
   geometry_msgs::msg::Pose pose;
   static rclcpp::Serialization<geometry_msgs::msg::Pose> serializer;
@@ -83,8 +84,9 @@ double getLaneletAngle(const lanelet::ConstLanelet & lanelet, const std::string 
   serialized_msg.reserve(message_header_length + point_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = point_byte.size();
   for (size_t i = 0; i < point_byte.size(); ++i) {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     serialized_msg.get_rcl_serialized_message().buffer[i] = point_byte[i];
+    // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   }
   geometry_msgs::msg::Point point;
   static rclcpp::Serialization<geometry_msgs::msg::Point> serializer;
@@ -100,8 +102,9 @@ bool isInLanelet(
   serialized_msg.reserve(message_header_length + pose_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = pose_byte.size();
   for (size_t i = 0; i < pose_byte.size(); ++i) {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];
+    // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   }
   geometry_msgs::msg::Pose pose;
   static rclcpp::Serialization<geometry_msgs::msg::Pose> serializer;
@@ -117,8 +120,9 @@ std::vector<double> getClosestCenterPose(
   serialized_point_msg.reserve(message_header_length + search_point_byte.size());
   serialized_point_msg.get_rcl_serialized_message().buffer_length = search_point_byte.size();
   for (size_t i = 0; i < search_point_byte.size(); ++i) {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     serialized_point_msg.get_rcl_serialized_message().buffer[i] = search_point_byte[i];
+    // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   }
   geometry_msgs::msg::Point search_point;
   static rclcpp::Serialization<geometry_msgs::msg::Point> serializer_point;
@@ -139,8 +143,9 @@ double getLateralDistanceToCenterline(
   serialized_msg.reserve(message_header_length + pose_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = pose_byte.size();
   for (size_t i = 0; i < pose_byte.size(); ++i) {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];
+    // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   }
   geometry_msgs::msg::Pose pose;
   static rclcpp::Serialization<geometry_msgs::msg::Pose> serializer;
@@ -156,8 +161,9 @@ double getLateralDistanceToClosestLanelet(
   serialized_msg.reserve(message_header_length + pose_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = pose_byte.size();
   for (size_t i = 0; i < pose_byte.size(); ++i) {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];
+    // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   }
   geometry_msgs::msg::Pose pose;
   static rclcpp::Serialization<geometry_msgs::msg::Pose> serializer;
@@ -240,8 +246,9 @@ lanelet::ConstLanelets getLaneletsWithinRange_point(
   serialized_msg.reserve(message_header_length + point_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = point_byte.size();
   for (size_t i = 0; i < point_byte.size(); ++i) {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     serialized_msg.get_rcl_serialized_message().buffer[i] = point_byte[i];
+    // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   }
   geometry_msgs::msg::Point point;
   static rclcpp::Serialization<geometry_msgs::msg::Point> serializer;
@@ -258,8 +265,9 @@ lanelet::ConstLanelets getLaneChangeableNeighbors_point(
   serialized_msg.reserve(message_header_length + point_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = point_byte.size();
   for (size_t i = 0; i < point_byte.size(); ++i) {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     serialized_msg.get_rcl_serialized_message().buffer[i] = point_byte[i];
+    // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   }
   geometry_msgs::msg::Point point;
   static rclcpp::Serialization<geometry_msgs::msg::Point> serializer;
@@ -276,8 +284,9 @@ lanelet::ConstLanelets getAllNeighbors_point(
   serialized_msg.reserve(message_header_length + point_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = point_byte.size();
   for (size_t i = 0; i < point_byte.size(); ++i) {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     serialized_msg.get_rcl_serialized_message().buffer[i] = point_byte[i];
+    // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   }
   geometry_msgs::msg::Point point;
   static rclcpp::Serialization<geometry_msgs::msg::Point> serializer;
@@ -293,8 +302,9 @@ lanelet::Optional<lanelet::ConstLanelet> getClosestLanelet(
   serialized_msg.reserve(message_header_length + pose_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = pose_byte.size();
   for (size_t i = 0; i < pose_byte.size(); ++i) {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];
+    // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   }
   geometry_msgs::msg::Pose pose;
   static rclcpp::Serialization<geometry_msgs::msg::Pose> serializer;
@@ -316,8 +326,9 @@ lanelet::Optional<lanelet::ConstLanelet> getClosestLaneletWithConstrains(
   serialized_msg.reserve(message_header_length + pose_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = pose_byte.size();
   for (size_t i = 0; i < pose_byte.size(); ++i) {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];
+    // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   }
   geometry_msgs::msg::Pose pose;
   static rclcpp::Serialization<geometry_msgs::msg::Pose> serializer;
@@ -338,8 +349,9 @@ lanelet::ConstLanelets getCurrentLanelets_point(
   serialized_msg.reserve(message_header_length + point_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = point_byte.size();
   for (size_t i = 0; i < point_byte.size(); ++i) {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     serialized_msg.get_rcl_serialized_message().buffer[i] = point_byte[i];
+    // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   }
   geometry_msgs::msg::Point point;
   static rclcpp::Serialization<geometry_msgs::msg::Point> serializer;
@@ -357,8 +369,9 @@ lanelet::ConstLanelets getCurrentLanelets_pose(
   serialized_msg.reserve(message_header_length + pose_byte.size());
   serialized_msg.get_rcl_serialized_message().buffer_length = pose_byte.size();
   for (size_t i = 0; i < pose_byte.size(); ++i) {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     serialized_msg.get_rcl_serialized_message().buffer[i] = pose_byte[i];
+    // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
   }
   geometry_msgs::msg::Pose pose;
   static rclcpp::Serialization<geometry_msgs::msg::Pose> serializer;


### PR DESCRIPTION
## Description

This PR fixes errors from cpplint in pre-commit ci.
When https://github.com/autowarefoundation/autoware_lanelet2_extension/pull/4 was merged, `// NOLINTNEXTLINE` was used to suppress errors. 

However, cpplint in version 1.6.1 does not recognize `cppcoreguidelines-pro-bounds-pointer-arithmetic` as a supported category and outputs the following error when you run `pre-commit run -a`
```
cpplint..................................................................Failed
- hook id: cpplint
- exit code: 1

autoware_lanelet2_extension_python/src/utility.cpp:70:  Unknown NOLINT error category: cppcoreguidelines-pro-bounds-pointer-arithmetic  [readability/nolint] [5]
autoware_lanelet2_extension_python/src/utility.cpp:86:  Unknown NOLINT error category: cppcoreguidelines-pro-bounds-pointer-arithmetic  [readability/nolint] [5]
autoware_lanelet2_extension_python/src/utility.cpp:103:  Unknown NOLINT error category: cppcoreguidelines-pro-bounds-pointer-arithmetic  [readability/nolint] [5]
autoware_lanelet2_extension_python/src/utility.cpp:120:  Unknown NOLINT error category: cppcoreguidelines-pro-bounds-pointer-arithmetic  [readability/nolint] [5]
autoware_lanelet2_extension_python/src/utility.cpp:142:  Unknown NOLINT error category: cppcoreguidelines-pro-bounds-pointer-arithmetic  [readability/nolint] [5]
autoware_lanelet2_extension_python/src/utility.cpp:159:  Unknown NOLINT error category: cppcoreguidelines-pro-bounds-pointer-arithmetic  [readability/nolint] [5]
autoware_lanelet2_extension_python/src/utility.cpp:243:  Unknown NOLINT error category: cppcoreguidelines-pro-bounds-pointer-arithmetic  [readability/nolint] [5]
autoware_lanelet2_extension_python/src/utility.cpp:261:  Unknown NOLINT error category: cppcoreguidelines-pro-bounds-pointer-arithmetic  [readability/nolint] [5]
autoware_lanelet2_extension_python/src/utility.cpp:279:  Unknown NOLINT error category: cppcoreguidelines-pro-bounds-pointer-arithmetic  [readability/nolint] [5]
autoware_lanelet2_extension_python/src/utility.cpp:296:  Unknown NOLINT error category: cppcoreguidelines-pro-bounds-pointer-arithmetic  [readability/nolint] [5]
autoware_lanelet2_extension_python/src/utility.cpp:319:  Unknown NOLINT error category: cppcoreguidelines-pro-bounds-pointer-arithmetic  [readability/nolint] [5]
autoware_lanelet2_extension_python/src/utility.cpp:341:  Unknown NOLINT error category: cppcoreguidelines-pro-bounds-pointer-arithmetic  [readability/nolint] [5]
autoware_lanelet2_extension_python/src/utility.cpp:360:  Unknown NOLINT error category: cppcoreguidelines-pro-bounds-pointer-arithmetic  [readability/nolint] [5]
Done processing autoware_lanelet2_extension_python/src/utility.cpp
Total errors found: 13
```


 We can instead use NOLINTBEGIN to generally ignore the lint for relevant lines.


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
