### PR TITLE
perf(query): add faster getLinkedParkingLot function

### DIFF
--- a/autoware_lanelet2_extension/include/autoware_lanelet2_extension/utility/query.hpp
+++ b/autoware_lanelet2_extension/include/autoware_lanelet2_extension/utility/query.hpp
@@ -167,6 +167,10 @@ bool getLinkedParkingLot(
 bool getLinkedParkingLot(
   const lanelet::BasicPoint2d & current_position, const lanelet::ConstPolygons3d & all_parking_lots,
   lanelet::ConstPolygon3d * linked_parking_lot);
+bool getLinkedParkingLot(
+  const lanelet::BasicPoint2d & current_position,
+  const lanelet::LaneletMapConstPtr & lanelet_map_ptr,
+  lanelet::ConstPolygon3d * linked_parking_lot);
 // get linked parking lot from parking space
 bool getLinkedParkingLot(
   const lanelet::ConstLineString3d & parking_space,

--- a/autoware_lanelet2_extension/lib/query.cpp
+++ b/autoware_lanelet2_extension/lib/query.cpp
@@ -549,6 +549,22 @@ bool getLinkedParkingLot(
   }
   return false;
 }
+bool getLinkedParkingLot(
+  const lanelet::BasicPoint2d & current_position,
+  const lanelet::LaneletMapConstPtr & lanelet_map_ptr, lanelet::ConstPolygon3d * linked_parking_lot)
+{
+  auto candidates =
+    lanelet_map_ptr->polygonLayer.search(lanelet::geometry::boundingBox2d(current_position));
+  candidates.erase(
+    std::remove_if(
+      candidates.begin(), candidates.end(),
+      [](const auto & c) {
+        const std::string type = c.attributeOr(lanelet::AttributeName::Type, "none");
+        return type != "parking_lot";
+      }),
+    candidates.end());
+  return getLinkedParkingLot(current_position, candidates, linked_parking_lot);
+}
 
 // get overlapping parking lot
 bool getLinkedParkingLot(


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Implement a more efficient `getLinkedParkingLot` that do not require providing ALL parking lots.
Instead an efficient query on the lanelet map is used.

Needed for https://github.com/autowarefoundation/autoware.universe/pull/7930

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
