### PR TITLE
feat(lanelet2_extension): add query for bicycle_lane

### DIFF
--- a/autoware_lanelet2_extension/include/autoware_lanelet2_extension/utility/query.hpp
+++ b/autoware_lanelet2_extension/include/autoware_lanelet2_extension/utility/query.hpp
@@ -56,6 +56,14 @@ lanelet::ConstLanelets walkwayLanelets(const lanelet::ConstLanelets & lls);
  * @return     [shoulder lanelets]
  */
 lanelet::ConstLanelets shoulderLanelets(const lanelet::ConstLanelets & lls);
+
+/**
+ * [bicycleLaneLanelets extracts shoulder lanelets]
+ * @param  lls [input lanelets possibly with subtype bicycle_lane]
+ * @return     [shoulder lanelets]
+ */
+lanelet::ConstLanelets bicycleLaneLanelets(const lanelet::ConstLanelets & lls);
+
 /**
  * [trafficLights extracts Traffic Light regulatory element from lanelets]
  * @param lanelets [input lanelets]

--- a/autoware_lanelet2_extension/lib/query.cpp
+++ b/autoware_lanelet2_extension/lib/query.cpp
@@ -72,6 +72,11 @@ lanelet::ConstLanelets shoulderLanelets(const lanelet::ConstLanelets & lls)
   return subtypeLanelets(lls, "road_shoulder");
 }
 
+lanelet::ConstLanelets bicycleLaneLanelets(const lanelet::ConstLanelets & lls)
+{
+  return subtypeLanelets(lls, "bicycle_lane");
+}
+
 std::vector<lanelet::TrafficLightConstPtr> trafficLights(const lanelet::ConstLanelets & lanelets)
 {
   std::vector<lanelet::TrafficLightConstPtr> tl_reg_elems;


### PR DESCRIPTION
## Description

added query function for "bicycle_lane"

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

with this PR, map_loader can visualize the bicycle_lane (used the map https://github.com/autowarefoundation/autoware.universe/tree/main/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/test_map/intersection)

![image](https://github.com/user-attachments/assets/f9f67097-7083-4480-93d6-ad8f6ac95461)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
