### PR TITLE
fix(Python bindings): add missing dependency to lanelet2

### DIFF
--- a/autoware_lanelet2_extension_python/autoware_lanelet2_extension_python/projection/__init__.py
+++ b/autoware_lanelet2_extension_python/autoware_lanelet2_extension_python/projection/__init__.py
@@ -1,3 +1,4 @@
+import lanelet2  # noqa: F401 # isort: skip
 import autoware_lanelet2_extension_python._autoware_lanelet2_extension_python_boost_python_projection as _projection_cpp
 
 MGRSProjector = _projection_cpp.MGRSProjector


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Due to the import order change in https://github.com/autowarefoundation/autoware_lanelet2_extension/pull/14, `example.py` is broken.

![image](https://github.com/user-attachments/assets/e33a3618-5333-4327-b31d-6f36cebc0510)

```bash
$ python3 autoware_lanelet2_extension_python/example/example.py
Traceback (most recent call last):
  File "/ws/autoware_lanelet2_extension_python/example/example.py", line 1, in <module>
    from autoware_lanelet2_extension_python.projection import MGRSProjector
  File "/ws/install/autoware_lanelet2_extension_python/local/lib/python3.10/dist-packages/autoware_lanelet2_extension_python/projection/__init__.py", line 2, in <module>
    import autoware_lanelet2_extension_python._autoware_lanelet2_extension_python_boost_python_projection as _projection_cpp
SystemError: initialization of _autoware_lanelet2_extension_python_boost_python_projection raised unreported exception
```

```python
>>> from autoware_lanelet2_extension_python.projection import MGRSProjector
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/ws/install/autoware_lanelet2_extension_python/local/lib/python3.10/dist-packages/autoware_lanelet2_extension_python/projection/__init__.py", line 2, in <module>
    import autoware_lanelet2_extension_python._autoware_lanelet2_extension_python_boost_python_projection as _projection_cpp
SystemError: initialization of _autoware_lanelet2_extension_python_boost_python_projection raised unreported exception

# It should be imported after lanelet2.
>>> import lanelet2
>>> from autoware_lanelet2_extension_python.projection import MGRSProjector
# No error.
```


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Tested the following steps with `osrf/ros:humble-desktop`.

```bash
$ vim autoware_lanelet2_extension_python/autoware_lanelet2_extension_python/projection/__init__.py # Add `import lanelet2`.
$ colcon build
$ python3
Python 3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from autoware_lanelet2_extension_python.projection import MGRSProjector
# No error.
```

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
