### PR TITLE
feat(lanelet2_extension)!: remove dependency on autoware_utils

### DIFF
--- a/autoware_lanelet2_extension/CMakeLists.txt
+++ b/autoware_lanelet2_extension/CMakeLists.txt
@@ -2,22 +2,6 @@ cmake_minimum_required(VERSION 3.14)
 project(autoware_lanelet2_extension)
 
 find_package(autoware_cmake REQUIRED)
-
-find_package(TinyXML2 CONFIG QUIET)
-if(NOT TinyXML2_FOUND)
-  find_path(TINYXML2_INCLUDE_DIR NAMES tinyxml2.h)
-  find_library(TINYXML2_LIBRARY tinyxml2)
-  include(FindPackageHandleStandardArgs)
-  find_package_handle_standard_args(TinyXML2 DEFAULT_MSG TINYXML2_LIBRARY TINYXML2_INCLUDE_DIR)
-  mark_as_advanced(TINYXML2_INCLUDE_DIR TINYXML2_LIBRARY)
-  if(NOT TARGET tinyxml2::tinyxml2)
-    add_library(tinyxml2::tinyxml2 UNKNOWN IMPORTED)
-    set_property(TARGET tinyxml2::tinyxml2 PROPERTY IMPORTED_LOCATION ${TINYXML2_LIBRARY})
-    set_property(TARGET tinyxml2::tinyxml2 PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${TINYXML2_INCLUDE_DIR})
-    list(APPEND TinyXML2_TARGETS tinyxml2::tinyxml2)
-  endif()
-endif()
-
 autoware_package()
 
 ament_auto_add_library(${PROJECT_NAME}_lib SHARED

--- a/autoware_lanelet2_extension/CMakeLists.txt
+++ b/autoware_lanelet2_extension/CMakeLists.txt
@@ -53,6 +53,8 @@ if(BUILD_TESTING)
   target_link_libraries(utilities-test ${PROJECT_NAME}_lib)
   ament_add_ros_isolated_gtest(route-test test/src/test_route_checker.cpp)
   target_link_libraries(route-test ${PROJECT_NAME}_lib)
+  ament_add_ros_isolated_gtest(normalize-radian test/src/test_normalize_radian.cpp)
+  target_link_libraries(normalize-radian ${PROJECT_NAME}_lib)
 endif()
 
 ament_auto_package()

--- a/autoware_lanelet2_extension/CMakeLists.txt
+++ b/autoware_lanelet2_extension/CMakeLists.txt
@@ -2,6 +2,22 @@ cmake_minimum_required(VERSION 3.14)
 project(autoware_lanelet2_extension)
 
 find_package(autoware_cmake REQUIRED)
+
+find_package(TinyXML2 CONFIG QUIET)
+if(NOT TinyXML2_FOUND)
+  find_path(TINYXML2_INCLUDE_DIR NAMES tinyxml2.h)
+  find_library(TINYXML2_LIBRARY tinyxml2)
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(TinyXML2 DEFAULT_MSG TINYXML2_LIBRARY TINYXML2_INCLUDE_DIR)
+  mark_as_advanced(TINYXML2_INCLUDE_DIR TINYXML2_LIBRARY)
+  if(NOT TARGET tinyxml2::tinyxml2)
+    add_library(tinyxml2::tinyxml2 UNKNOWN IMPORTED)
+    set_property(TARGET tinyxml2::tinyxml2 PROPERTY IMPORTED_LOCATION ${TINYXML2_LIBRARY})
+    set_property(TARGET tinyxml2::tinyxml2 PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${TINYXML2_INCLUDE_DIR})
+    list(APPEND TinyXML2_TARGETS tinyxml2::tinyxml2)
+  endif()
+endif()
+
 autoware_package()
 
 ament_auto_add_library(${PROJECT_NAME}_lib SHARED

--- a/autoware_lanelet2_extension/lib/normalize_radian.hpp
+++ b/autoware_lanelet2_extension/lib/normalize_radian.hpp
@@ -1,0 +1,38 @@
+// Copyright 2025 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cmath>
+#include <utility>
+
+#ifndef AUTOWARE_LANELET2_EXTENSION__LIB__NORMALIZE_RADIAN_HPP_
+#define AUTOWARE_LANELET2_EXTENSION__LIB__NORMALIZE_RADIAN_HPP_
+
+namespace lanelet::utils::impl
+{
+inline double normalize_radian(const double rad)
+{
+  constexpr double pi = 3.14159265358979323846;  // To be replaced by std::numbers::pi in C++20
+  constexpr double min_rad = -pi;
+  const auto max_rad = min_rad + 2 * pi;
+
+  const auto value = std::fmod(rad, 2 * pi);
+  if (min_rad <= value && value < max_rad) {
+    return value;
+  }
+
+  return value - std::copysign(2 * pi, value);
+}
+}  // namespace lanelet::utils::impl
+
+#endif  // AUTOWARE_LANELET2_EXTENSION__LIB__NORMALIZE_RADIAN_HPP_

--- a/autoware_lanelet2_extension/lib/query.cpp
+++ b/autoware_lanelet2_extension/lib/query.cpp
@@ -28,9 +28,6 @@
 #include "autoware_lanelet2_extension/utility/message_conversion.hpp"
 #include "autoware_lanelet2_extension/utility/utilities.hpp"
 
-#include <Eigen/Eigen>
-#include <autoware_utils/autoware_utils.hpp>
-
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/geometry/Lanelet.h>
 #include <lanelet2_core/primitives/Lanelet.h>
@@ -53,6 +50,24 @@
 #include <vector>
 
 using lanelet::utils::to2D;
+
+namespace
+{
+
+inline double normalize_radian(const double rad)
+{
+  constexpr double pi = 3.14159265358979323846;  // To be replaced by std::numbers::pi in C++20
+  constexpr double min_rad = -pi;
+  const auto max_rad = min_rad + 2 * pi;
+
+  const auto value = std::fmod(rad, 2 * pi);
+  if (min_rad <= value && value < max_rad) {
+    return value;
+  }
+
+  return value - std::copysign(2 * pi, value);
+}
+}  // namespace
 
 namespace lanelet::utils
 {
@@ -934,7 +949,7 @@ bool query::getClosestLanelet(
       if (!segment.empty()) {
         double segment_angle = std::atan2(
           segment.back().y() - segment.front().y(), segment.back().x() - segment.front().x());
-        angle_diff = std::abs(autoware_utils::normalize_radian(segment_angle - pose_yaw));
+        angle_diff = std::abs(::normalize_radian(segment_angle - pose_yaw));
       }
       if (angle_diff < min_angle) {
         min_angle = angle_diff;
@@ -996,7 +1011,7 @@ bool query::getClosestLaneletWithConstrains(
       const auto & distance = llt_pair.second;
 
       double lanelet_angle = getLaneletAngle(llt_pair.first, search_pose.position);
-      double angle_diff = std::abs(autoware_utils::normalize_radian(lanelet_angle - pose_yaw));
+      double angle_diff = std::abs(::normalize_radian(lanelet_angle - pose_yaw));
 
       if (angle_diff > std::abs(yaw_threshold)) continue;
       if (min_distance < distance) break;

--- a/autoware_lanelet2_extension/lib/query.cpp
+++ b/autoware_lanelet2_extension/lib/query.cpp
@@ -42,6 +42,8 @@
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 #endif
 
+#include "./normalize_radian.hpp"
+
 #include <deque>
 #include <limits>
 #include <memory>
@@ -50,24 +52,6 @@
 #include <vector>
 
 using lanelet::utils::to2D;
-
-namespace
-{
-
-inline double normalize_radian(const double rad)
-{
-  constexpr double pi = 3.14159265358979323846;  // To be replaced by std::numbers::pi in C++20
-  constexpr double min_rad = -pi;
-  const auto max_rad = min_rad + 2 * pi;
-
-  const auto value = std::fmod(rad, 2 * pi);
-  if (min_rad <= value && value < max_rad) {
-    return value;
-  }
-
-  return value - std::copysign(2 * pi, value);
-}
-}  // namespace
 
 namespace lanelet::utils
 {
@@ -949,7 +933,7 @@ bool query::getClosestLanelet(
       if (!segment.empty()) {
         double segment_angle = std::atan2(
           segment.back().y() - segment.front().y(), segment.back().x() - segment.front().x());
-        angle_diff = std::abs(::normalize_radian(segment_angle - pose_yaw));
+        angle_diff = std::abs(impl::normalize_radian(segment_angle - pose_yaw));
       }
       if (angle_diff < min_angle) {
         min_angle = angle_diff;
@@ -1011,7 +995,7 @@ bool query::getClosestLaneletWithConstrains(
       const auto & distance = llt_pair.second;
 
       double lanelet_angle = getLaneletAngle(llt_pair.first, search_pose.position);
-      double angle_diff = std::abs(::normalize_radian(lanelet_angle - pose_yaw));
+      double angle_diff = std::abs(impl::normalize_radian(lanelet_angle - pose_yaw));
 
       if (angle_diff > std::abs(yaw_threshold)) continue;
       if (min_distance < distance) break;

--- a/autoware_lanelet2_extension/package.xml
+++ b/autoware_lanelet2_extension/package.xml
@@ -17,7 +17,6 @@
 
   <depend>autoware_map_msgs</depend>
   <depend>autoware_planning_msgs</depend>
-  <depend>autoware_utils</depend>
   <depend>geographiclib</depend>
   <depend>geometry_msgs</depend>
   <depend>lanelet2_core</depend>

--- a/autoware_lanelet2_extension/package.xml
+++ b/autoware_lanelet2_extension/package.xml
@@ -31,6 +31,7 @@
   <depend>rclcpp</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
+  <depend>tinyxml2_vendor</depend>
   <depend>visualization_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>

--- a/autoware_lanelet2_extension/package.xml
+++ b/autoware_lanelet2_extension/package.xml
@@ -31,7 +31,6 @@
   <depend>rclcpp</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
-  <depend>tinyxml2_vendor</depend>
   <depend>visualization_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>

--- a/autoware_lanelet2_extension/test/src/test_normalize_radian.cpp
+++ b/autoware_lanelet2_extension/test/src/test_normalize_radian.cpp
@@ -1,0 +1,32 @@
+// Copyright 2025 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOLINTBEGIN(readability-identifier-naming)
+
+#include "../../lib/normalize_radian.hpp"
+
+#include <gtest/gtest.h>
+
+TEST(normalize_radian, normalize_radian_test)
+{
+  EXPECT_FLOAT_EQ(lanelet::utils::impl::normalize_radian(M_PI * 1.5), M_PI * (-0.5));
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+
+// NOLINTEND(readability-identifier-naming)

--- a/build_depends.repos
+++ b/build_depends.repos
@@ -7,7 +7,3 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_msgs.git
     version: main
-  autoware_utils:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_utils.git
-    version: main


### PR DESCRIPTION
## Description

remove dependency on autoware_utils for simplicity.

In a few months, utility/query/ will be removed from this package and lanelet2_extension will become just a pure "extension" of lanelet2.

## How was this PR tested?

build passes

## Notes for reviewers

None.

## Effects on system behavior

None.
