### PR TITLE
chore(sync-files.yaml): append `build-and-test*.yaml`

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -28,6 +28,12 @@
     - source: .prettierignore
     - source: .prettierrc.yaml
     - source: .yamllint.yaml
+    - source: .github/workflows/build-and-test.yaml
+      pre-commands: |
+        sed -i '/build-depends-repos/d' {source}
+    - source: .github/workflows/build-and-test-differential.yaml
+      pre-commands: |
+        sed -i '/build-depends-repos/d' {source}
     - source: CPPLINT.cfg
       pre-commands: |
         sd 'filter=-whitespace/braces.*' '\n# https://github.com/cpplint/cpplint/issues/298 for the next filter\nfilter=-readability/nolint        # NOLINTBEGIN(*) and NOLINTEND(*) conflict with clang-tidy\n\nfilter=-whitespace/braces         # we wrap open curly braces for namespaces, classes and functions' {source}


### PR DESCRIPTION
## Description

This PR appends `build-and-test` and `build-and-test-differential` files to `syn-files.yaml`.

Ref.
- https://github.com/autowarefoundation/autoware/pull/5890

## How was this PR tested?

- https://github.com/autowarefoundation/autoware_lanelet2_extension/pull/46
- https://github.com/autowarefoundation/autoware_lanelet2_extension/actions/runs/13890551966

## Notes for reviewers

None.

## Effects on system behavior

None.
