### PR TITLE
feat(autoware_lanelet2_extension): add waypoint_zone

### DIFF
--- a/autoware_lanelet2_extension/include/autoware_lanelet2_extension/utility/query.hpp
+++ b/autoware_lanelet2_extension/include/autoware_lanelet2_extension/utility/query.hpp
@@ -134,6 +134,9 @@ lanelet::ConstPolygons3d getAllObstaclePolygons(
 // query all parking lots in lanelet2 map
 lanelet::ConstPolygons3d getAllParkingLots(const lanelet::LaneletMapConstPtr & lanelet_map_ptr);
 
+// query all waypoint zones in lanelet2 map
+lanelet::ConstPolygons3d getAllWaypointZones(const lanelet::LaneletMapConstPtr & lanelet_map_ptr);
+
 // query all partitions in lanelet2 map
 lanelet::ConstLineStrings3d getAllPartitions(const lanelet::LaneletMapConstPtr & lanelet_map_ptr);
 
@@ -190,6 +193,28 @@ bool getLinkedParkingLot(
 bool getLinkedParkingLot(
   const lanelet::ConstLineString3d & parking_space,
   const lanelet::ConstPolygons3d & all_parking_lots, lanelet::ConstPolygon3d * linked_parking_lot);
+
+// get linked waypoint zone from lanelet
+bool getLinkedWaypointZone(
+  const lanelet::ConstLanelet & lanelet, const lanelet::ConstPolygons3d & all_waypoint_zones,
+  lanelet::ConstPolygon3d * linked_waypoint_zone);
+// get linked waypoint zone from current pose of ego car
+bool getLinkedWaypointZone(
+  const lanelet::BasicPoint2d & current_position,
+  const lanelet::ConstPolygons3d & all_waypoint_zones,
+  lanelet::ConstPolygon3d * linked_waypoint_zone);
+bool getLinkedWaypointZone(
+  const lanelet::BasicPoint2d & current_position,
+  const lanelet::ConstPolygons3d & all_waypoint_zones,
+  lanelet::ConstPolygon3d * linked_waypoint_zone, double threshold);
+bool getLinkedWaypointZone(
+  const lanelet::BasicPoint2d & current_position,
+  const lanelet::LaneletMapConstPtr & lanelet_map_ptr,
+  lanelet::ConstPolygon3d * linked_waypoint_zone);
+bool getLinkedWaypointZone(
+  const lanelet::BasicPoint2d & current_position,
+  const lanelet::LaneletMapConstPtr & lanelet_map_ptr,
+  lanelet::ConstPolygon3d * linked_waypoint_zone, double threshold);
 
 // query linked parking space from parking lot
 lanelet::ConstLineStrings3d getLinkedParkingSpaces(

--- a/autoware_lanelet2_extension/include/autoware_lanelet2_extension/visualization/visualization.hpp
+++ b/autoware_lanelet2_extension/include/autoware_lanelet2_extension/visualization/visualization.hpp
@@ -179,6 +179,14 @@ visualization_msgs::msg::MarkerArray parkingLotsAsMarkerArray(
   const lanelet::ConstPolygons3d & parking_lots, const std_msgs::msg::ColorRGBA & c);
 
 /**
+ * [waypointZonesAsMarkerArray creates marker array to visualize parking lots]
+ * @param  waypoint_zones [waypoint zone polygon]
+ * @param  c              [color of the marker]
+ */
+visualization_msgs::msg::MarkerArray waypointZonesAsMarkerArray(
+  const lanelet::ConstPolygons3d & waypoint_zones, const std_msgs::msg::ColorRGBA & c);
+
+/**
  * [parkingSpacesAsMarkerArray creates marker array to visualize parking spaces]
  * @param  parking_spaces [parking space line string]
  * @param  c            [color of the marker]

--- a/autoware_lanelet2_extension/lib/query.cpp
+++ b/autoware_lanelet2_extension/lib/query.cpp
@@ -332,6 +332,22 @@ lanelet::ConstPolygons3d getAllParkingLots(const lanelet::LaneletMapConstPtr & l
   return parking_lots;
 }
 
+lanelet::ConstPolygons3d getAllWaypointZones(const lanelet::LaneletMapConstPtr & lanelet_map_ptr)
+{
+  lanelet::ConstPolygons3d waypoint_zones;
+  if (!lanelet_map_ptr) {
+    return waypoint_zones;
+  }
+
+  for (const auto & poly : lanelet_map_ptr->polygonLayer) {
+    const std::string type_val = poly.attributeOr(lanelet::AttributeName::Type, "none");
+    if (type_val == "waypoint_zone") {
+      waypoint_zones.push_back(poly);
+    }
+  }
+  return waypoint_zones;
+}
+
 lanelet::ConstLineStrings3d getAllPartitions(const lanelet::LaneletMapConstPtr & lanelet_map_ptr)
 {
   lanelet::ConstLineStrings3d partitions;
@@ -608,6 +624,93 @@ bool getLinkedParkingLot(
     }
   }
   return false;
+}
+
+// get overlapping waypoint zone
+bool getLinkedWaypointZone(
+  const lanelet::ConstLanelet & lanelet, const lanelet::ConstPolygons3d & all_waypoint_zones,
+  lanelet::ConstPolygon3d * linked_waypoint_zone)
+{
+  for (const auto & waypoint_zone : all_waypoint_zones) {
+    const double distance = boost::geometry::distance(
+      lanelet.polygon2d().basicPolygon(), to2D(waypoint_zone).basicPolygon());
+    if (distance < std::numeric_limits<double>::epsilon()) {
+      *linked_waypoint_zone = waypoint_zone;
+      return true;
+    }
+  }
+  return false;
+}
+
+// get overlapping waypoint zone
+bool getLinkedWaypointZone(
+  const lanelet::BasicPoint2d & current_position,
+  const lanelet::ConstPolygons3d & all_waypoint_zones,
+  lanelet::ConstPolygon3d * linked_waypoint_zone)
+{
+  for (const auto & waypoint_zone : all_waypoint_zones) {
+    const double distance =
+      boost::geometry::distance(current_position, to2D(waypoint_zone).basicPolygon());
+    if (distance < std::numeric_limits<double>::epsilon()) {
+      *linked_waypoint_zone = waypoint_zone;
+      return true;
+    }
+  }
+  return false;
+}
+
+// get overlapping waypoint zone
+bool getLinkedWaypointZone(
+  const lanelet::BasicPoint2d & current_position,
+  const lanelet::ConstPolygons3d & all_waypoint_zones,
+  lanelet::ConstPolygon3d * linked_waypoint_zone, double threshold)
+{
+  for (const auto & waypoint_zone : all_waypoint_zones) {
+    const double distance =
+      boost::geometry::distance(current_position, to2D(waypoint_zone).basicPolygon());
+    if (distance < threshold) {
+      *linked_waypoint_zone = waypoint_zone;
+      return true;
+    }
+  }
+  return false;
+}
+
+bool getLinkedWaypointZone(
+  const lanelet::BasicPoint2d & current_position,
+  const lanelet::LaneletMapConstPtr & lanelet_map_ptr,
+  lanelet::ConstPolygon3d * linked_waypoint_zone)
+{
+  auto candidates =
+    lanelet_map_ptr->polygonLayer.search(lanelet::geometry::boundingBox2d(current_position));
+  candidates.erase(
+    std::remove_if(
+      candidates.begin(), candidates.end(),
+      [](const auto & c) {
+        const std::string type = c.attributeOr(lanelet::AttributeName::Type, "none");
+        return type != "waypoint_zone";
+      }),
+    candidates.end());
+  return getLinkedWaypointZone(current_position, candidates, linked_waypoint_zone);
+}
+
+// get linked waypoint zone with specific distance
+bool getLinkedWaypointZone(
+  const lanelet::BasicPoint2d & current_position,
+  const lanelet::LaneletMapConstPtr & lanelet_map_ptr,
+  lanelet::ConstPolygon3d * linked_waypoint_zone, double threshold)
+{
+  auto candidates =
+    lanelet_map_ptr->polygonLayer.search(lanelet::geometry::boundingBox2d(current_position));
+  candidates.erase(
+    std::remove_if(
+      candidates.begin(), candidates.end(),
+      [](const auto & c) {
+        const std::string type = c.attributeOr(lanelet::AttributeName::Type, "none");
+        return type != "waypoint_zone";
+      }),
+    candidates.end());
+  return getLinkedWaypointZone(current_position, candidates, linked_waypoint_zone, threshold);
 }
 
 lanelet::ConstLineStrings3d getLinkedParkingSpaces(

--- a/autoware_lanelet2_extension/lib/visualization.cpp
+++ b/autoware_lanelet2_extension/lib/visualization.cpp
@@ -994,6 +994,26 @@ visualization_msgs::msg::MarkerArray parkingLotsAsMarkerArray(
   }
   return marker_array;
 }
+
+visualization_msgs::msg::MarkerArray waypointZonesAsMarkerArray(
+  const lanelet::ConstPolygons3d & waypoint_zones, const std_msgs::msg::ColorRGBA & c)
+{
+  visualization_msgs::msg::MarkerArray marker_array;
+  if (waypoint_zones.empty()) {
+    return marker_array;
+  }
+
+  visualization_msgs::msg::Marker marker = createPolygonMarker("waypoint_zones", c);
+  for (const auto & polygon : waypoint_zones) {
+    pushPolygonMarker(&marker, polygon, c);
+  }
+
+  if (!marker.points.empty()) {
+    marker_array.markers.push_back(marker);
+  }
+  return marker_array;
+}
+
 visualization_msgs::msg::MarkerArray parkingSpacesAsMarkerArray(
   const lanelet::ConstLineStrings3d & parking_spaces, const std_msgs::msg::ColorRGBA & c)
 {


### PR DESCRIPTION
## Description

It adds waypoint_zone for close area advanced development project.
The waypoint_zone is defined as similar with parking_space as:
```
  <way id="10150">
    <nd ref="10146"/>
    <nd ref="10147"/>
    <nd ref="10148"/>
    <nd ref="10149"/>
    <tag k="type" v="waypoint_zone"/>
    <tag k="area" v="yes"/>
  </way>
```
  
 The purpose of waypoint_zone is to switch the scenario to waypoint following mode in scenario_selector when the vehicle is close to or within a waypoint_zone.

For example, the orange zone is the waypoint_zone with a pre-loaded path.
![Screenshot from 2025-03-26 14-50-56](https://github.com/user-attachments/assets/9d184f42-525c-4422-a7dd-845d7345c034)

## How was this PR tested?
In Psim.

## Notes for reviewers

This PR is for CAAD project.

## Effects on system behavior

It will trigger the waypoint following mode when the vehicle is close to or within a waypoint_zone.
