### PR TITLE
fix(autoware_lanelet2_extension): not use obsolete header

### DIFF
--- a/autoware_lanelet2_extension/lib/query.cpp
+++ b/autoware_lanelet2_extension/lib/query.cpp
@@ -28,11 +28,12 @@
 #include "autoware_lanelet2_extension/utility/message_conversion.hpp"
 #include "autoware_lanelet2_extension/utility/utilities.hpp"
 
+#include <tf2/utils.hpp>
+
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/geometry/Lanelet.h>
 #include <lanelet2_core/primitives/Lanelet.h>
 #include <lanelet2_routing/RoutingGraph.h>
-#include <tf2/utils.hpp>
 
 #include <iostream>
 #include <utility>

--- a/autoware_lanelet2_extension/lib/query.cpp
+++ b/autoware_lanelet2_extension/lib/query.cpp
@@ -32,7 +32,7 @@
 #include <lanelet2_core/geometry/Lanelet.h>
 #include <lanelet2_core/primitives/Lanelet.h>
 #include <lanelet2_routing/RoutingGraph.h>
-#include <tf2/utils.h>
+#include <tf2/utils.hpp>
 
 #include <iostream>
 #include <utility>


### PR DESCRIPTION
## Description

This PR fixes the following error.
https://build.ros2.org/job/Rbin_unv8_uNv8__autoware_lanelet2_extension__ubuntu_noble_arm64__binary/99/console
```
03:59:37 /opt/ros/rolling/include/tf2/tf2/utils.h:30:13: error: This header is obsolete, please include 'tf2/utils.hpp' instead [-Werror]
```

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
