### PR TITLE
fix(autoware_lanelet2_extension): point on the edge of a triangle was  not treated as inside the triangle

### DIFF
--- a/autoware_lanelet2_extension/lib/visualization.cpp
+++ b/autoware_lanelet2_extension/lib/visualization.cpp
@@ -289,7 +289,7 @@ bool isWithinTriangle(
   double c2 = (c.x - b.x) * (p.y - c.y) - (c.y - b.y) * (p.x - c.x);
   double c3 = (a.x - c.x) * (p.y - a.y) - (a.y - c.y) * (p.x - a.x);
 
-  return (c1 > 0.0 && c2 > 0.0 && c3 > 0.0) || (c1 < 0.0 && c2 < 0.0 && c3 < 0.0);
+  return (c1 >= 0.0 && c2 >= 0.0 && c3 >= 0.0) || (c1 <= 0.0 && c2 <= 0.0 && c3 <= 0.0);
 }
 
 visualization_msgs::msg::Marker createPolygonMarker(


### PR DESCRIPTION
## Description

Function `visualization::polygon2Triangle`  can get polygon with shape of rectangle with redundant points. Function `isWithinTriangle` treats points on the edge of a triangle as _outside point_ and it causes wrong selecting an ear in the polygon: 

![image](https://github.com/user-attachments/assets/6c253ffe-8de9-4ee5-bc3e-33f13e37b31f)

This causes creating wrong polygon in the next steps with warning `Could not find valid vertex for ear clipping triangulation. Triangulation result might be invalid`:

![image](https://github.com/user-attachments/assets/dee0e691-8a71-4e27-a7a4-4229b92b2388)

The problem was hidden because triangles was very small and invisible in RVIZ.

## Effects on system behavior

The enormous amount of logs:

![image](https://github.com/user-attachments/assets/6f4ea6de-0aef-47e4-abbb-b6f833723654)

## Solution

`isWithinTriangle` now checks points on the edge of a triangle.

## How was this PR tested?

I just compiled and ran on the carla simulator and logs gone without problems with rendering lanelets.

## Notes for reviewers

None.