### PR TITLE
fix: skip duplicate marker

### DIFF
--- a/autoware_lanelet2_extension/lib/visualization.cpp
+++ b/autoware_lanelet2_extension/lib/visualization.cpp
@@ -374,7 +374,11 @@ visualization_msgs::msg::MarkerArray autowareTrafficLightsAsMarkerArray(
   for (const auto & tl : tl_reg_elems) {
     const auto lights = tl->trafficLights();
     for (const auto & lsp : lights) {
-      if (lsp.isLineString() && !exists(traffic_light_triangle_id_list, lsp.id())) {  // traffic lights can either polygons or linestrings
+      if (lsp.isLineString() && !exists(traffic_light_triangle_id_list, lsp.id())) {  // traffic
+                                                                                      // lights can
+                                                                                      // either
+                                                                                      // polygons or
+                                                                                      // linestrings
         lanelet::ConstLineString3d ls = static_cast<lanelet::ConstLineString3d>(lsp);
         marker_tri.id++;
         pushTrafficLightTriangleMarker(&marker_tri, ls, c, scale);
@@ -388,7 +392,8 @@ visualization_msgs::msg::MarkerArray autowareTrafficLightsAsMarkerArray(
       lanelet::ConstLineString3d l = static_cast<lanelet::ConstLineString3d>(ls);
       for (const auto & pt : l) {
         if (pt.hasAttribute("color")) {
-          if (!exists(traffic_light_triangle_id_list, pt.id()) && inputLightMarker(&marker_sph, pt)) {
+          if (
+            !exists(traffic_light_triangle_id_list, pt.id()) && inputLightMarker(&marker_sph, pt)) {
             marker_sph.id++;
             tl_marker_array.markers.push_back(marker_sph);
             traffic_light_id_list.insert(pt.id());


### PR DESCRIPTION
## Description
When you run Autoware with AWSIM's nishishinjuku map, it produces 
`Multiple Markers in the same MarkerArray message had the same ns and id: (traffic_light, 70127)`. This happens when the same traffic light is referred by different lanes. (e.g., if you have multiple lanes coming from the same direction)

This will fix the error by checking if the marker was already added.

## How was this PR tested?

Tested with nishishinjuku map that you can download from [AWSIM tutorial](https://tier4.github.io/AWSIM/GettingStarted/QuickStartDemo/).

## Notes for reviewers

None.

## Effects on system behavior

None.
