### PR TITLE
add getLaneletAngleOnEgoCenterline

### DIFF
--- a/autoware_lanelet2_extension/include/autoware_lanelet2_extension/utility/utilities.hpp
+++ b/autoware_lanelet2_extension/include/autoware_lanelet2_extension/utility/utilities.hpp
@@ -104,6 +104,9 @@ lanelet::CompoundPolygon3d getPolygonFromArcLength(
   const lanelet::ConstLanelets & lanelets, const double s1, const double s2);
 double getLaneletAngle(
   const lanelet::ConstLanelet & lanelet, const geometry_msgs::msg::Point & search_point);
+double getLaneletAngleOnEgoCenterline(
+  const lanelet::ConstLanelet & lanelet, const geometry_msgs::msg::Point & search_point,
+  const lanelet::LaneletMapConstPtr & lanelet_map_ptr);
 bool isInLanelet(
   const geometry_msgs::msg::Pose & current_pose, const lanelet::ConstLanelet & lanelet,
   const double radius = 0.0);

--- a/autoware_lanelet2_extension/lib/utilities.cpp
+++ b/autoware_lanelet2_extension/lib/utilities.cpp
@@ -776,6 +776,23 @@ double getLaneletAngle(
     segment.back().y() - segment.front().y(), segment.back().x() - segment.front().x());
 }
 
+double getLaneletAngleOnEgoCenterline(
+  const lanelet::ConstLanelet & lanelet, const geometry_msgs::msg::Point & search_point,
+  const lanelet::LaneletMapConstPtr & lanelet_map_ptr)
+{
+  ConstLineString3d centerline;
+  if (lanelet.hasAttribute("waypoints")) {
+    const auto waypoints_id = lanelet.attribute("waypoints").asId().value();
+    centerline = lanelet_map_ptr->lineStringLayer.get(waypoints_id);
+  } else {
+    centerline = lanelet.centerline();
+  }
+  lanelet::BasicPoint2d llt_search_point(search_point.x, search_point.y);
+  lanelet::ConstLineString3d segment = getClosestSegment(llt_search_point, centerline);
+  return std::atan2(
+    segment.back().y() - segment.front().y(), segment.back().x() - segment.front().x());
+}
+
 bool isInLanelet(
   const geometry_msgs::msg::Pose & current_pose, const lanelet::ConstLanelet & lanelet,
   const double radius)


### PR DESCRIPTION
## Description

This PR adds a function called `getLaneletAngleOnEgoCenterline()`.

`getLaneletAngleOnEgoCenterline()` does the same job as `getLaneletAngle()` but considers `waypoint` `(custom centerline)` attribute as well if defined in the lanelet

## How was this PR tested?

Tested with the maps that has waypoints (custom centerline)

## Notes for reviewers

None.

## Effects on system behavior

None.
