### PR TITLE
feat: add linestring with type getter

### DIFF
--- a/autoware_lanelet2_extension/include/autoware_lanelet2_extension/utility/query.hpp
+++ b/autoware_lanelet2_extension/include/autoware_lanelet2_extension/utility/query.hpp
@@ -134,6 +134,7 @@ lanelet::ConstPolygons3d getAllObstaclePolygons(
 // query all parking lots in lanelet2 map
 lanelet::ConstPolygons3d getAllParkingLots(const lanelet::LaneletMapConstPtr & lanelet_map_ptr);
 
+// query all linestrings with defined type in lanelet2 map
 lanelet::ConstLineStrings3d getAllLinestringsWithType(
   const lanelet::LaneletMapConstPtr & lanelet_map_ptr, const std::string & type);
 

--- a/autoware_lanelet2_extension/include/autoware_lanelet2_extension/utility/query.hpp
+++ b/autoware_lanelet2_extension/include/autoware_lanelet2_extension/utility/query.hpp
@@ -144,9 +144,6 @@ lanelet::ConstLineStrings3d getAllPartitions(const lanelet::LaneletMapConstPtr &
 // query all fences in lanelet2 map
 lanelet::ConstLineStrings3d getAllFences(const lanelet::LaneletMapConstPtr & lanelet_map_ptr);
 
-// query all road borders in lanelet2 map
-lanelet::ConstLineStrings3d getAllRoadBorders(const lanelet::LaneletMapConstPtr & lanelet_map_ptr);
-
 // query all pedestrian polygon markings in lanelet2 map
 lanelet::ConstLineStrings3d getAllPedestrianPolygonMarkings(
   const lanelet::LaneletMapConstPtr & lanelet_map_ptr);

--- a/autoware_lanelet2_extension/include/autoware_lanelet2_extension/utility/query.hpp
+++ b/autoware_lanelet2_extension/include/autoware_lanelet2_extension/utility/query.hpp
@@ -140,6 +140,9 @@ lanelet::ConstLineStrings3d getAllPartitions(const lanelet::LaneletMapConstPtr &
 // query all fences in lanelet2 map
 lanelet::ConstLineStrings3d getAllFences(const lanelet::LaneletMapConstPtr & lanelet_map_ptr);
 
+// query all road borders in lanelet2 map
+lanelet::ConstLineStrings3d getAllRoadBorders(const lanelet::LaneletMapConstPtr & lanelet_map_ptr);
+
 // query all pedestrian polygon markings in lanelet2 map
 lanelet::ConstLineStrings3d getAllPedestrianPolygonMarkings(
   const lanelet::LaneletMapConstPtr & lanelet_map_ptr);

--- a/autoware_lanelet2_extension/include/autoware_lanelet2_extension/utility/query.hpp
+++ b/autoware_lanelet2_extension/include/autoware_lanelet2_extension/utility/query.hpp
@@ -134,6 +134,9 @@ lanelet::ConstPolygons3d getAllObstaclePolygons(
 // query all parking lots in lanelet2 map
 lanelet::ConstPolygons3d getAllParkingLots(const lanelet::LaneletMapConstPtr & lanelet_map_ptr);
 
+lanelet::ConstLineStrings3d getAllLinestringsWithType(
+  const lanelet::LaneletMapConstPtr & lanelet_map_ptr, const std::string & type);
+
 // query all partitions in lanelet2 map
 lanelet::ConstLineStrings3d getAllPartitions(const lanelet::LaneletMapConstPtr & lanelet_map_ptr);
 

--- a/autoware_lanelet2_extension/lib/query.cpp
+++ b/autoware_lanelet2_extension/lib/query.cpp
@@ -356,6 +356,18 @@ lanelet::ConstLineStrings3d getAllFences(const lanelet::LaneletMapConstPtr & lan
   return fences;
 }
 
+lanelet::ConstLineStrings3d getAllRoadBorders(const lanelet::LaneletMapConstPtr & lanelet_map_ptr)
+{
+  lanelet::ConstLineStrings3d road_borders;
+  for (const auto & ls : lanelet_map_ptr->lineStringLayer) {
+    const std::string type = ls.attributeOr(lanelet::AttributeName::Type, "none");
+    if (type == "road_border") {
+      road_borders.push_back(ls);
+    }
+  }
+  return road_borders;
+}
+
 lanelet::ConstLineStrings3d getAllPedestrianPolygonMarkings(
   const lanelet::LaneletMapConstPtr & lanelet_map_ptr)
 {

--- a/autoware_lanelet2_extension/lib/query.cpp
+++ b/autoware_lanelet2_extension/lib/query.cpp
@@ -369,11 +369,6 @@ lanelet::ConstLineStrings3d getAllFences(const lanelet::LaneletMapConstPtr & lan
   return fences;
 }
 
-lanelet::ConstLineStrings3d getAllRoadBorders(const lanelet::LaneletMapConstPtr & lanelet_map_ptr)
-{
-  return getAllLinestringsWithType(lanelet_map_ptr, "road_border");
-}
-
 lanelet::ConstLineStrings3d getAllPedestrianPolygonMarkings(
   const lanelet::LaneletMapConstPtr & lanelet_map_ptr)
 {

--- a/autoware_lanelet2_extension/lib/query.cpp
+++ b/autoware_lanelet2_extension/lib/query.cpp
@@ -332,6 +332,19 @@ lanelet::ConstPolygons3d getAllParkingLots(const lanelet::LaneletMapConstPtr & l
   return parking_lots;
 }
 
+lanelet::ConstLineStrings3d getAllLinestringsWithType(
+  const lanelet::LaneletMapConstPtr & lanelet_map_ptr, const std::string & type)
+{
+  lanelet::ConstLineStrings3d linestrings_with_type;
+  for (const auto & ls : lanelet_map_ptr->lineStringLayer) {
+    const std::string ls_type = ls.attributeOr(lanelet::AttributeName::Type, "none");
+    if (ls_type == type) {
+      linestrings_with_type.push_back(ls);
+    }
+  }
+  return linestrings_with_type;
+}
+
 lanelet::ConstLineStrings3d getAllPartitions(const lanelet::LaneletMapConstPtr & lanelet_map_ptr)
 {
   lanelet::ConstLineStrings3d partitions;
@@ -358,14 +371,7 @@ lanelet::ConstLineStrings3d getAllFences(const lanelet::LaneletMapConstPtr & lan
 
 lanelet::ConstLineStrings3d getAllRoadBorders(const lanelet::LaneletMapConstPtr & lanelet_map_ptr)
 {
-  lanelet::ConstLineStrings3d road_borders;
-  for (const auto & ls : lanelet_map_ptr->lineStringLayer) {
-    const std::string type = ls.attributeOr(lanelet::AttributeName::Type, "none");
-    if (type == "road_border") {
-      road_borders.push_back(ls);
-    }
-  }
-  return road_borders;
+  return getAllLinestringsWithType(lanelet_map_ptr, "road_border");
 }
 
 lanelet::ConstLineStrings3d getAllPedestrianPolygonMarkings(


### PR DESCRIPTION
## Description

Adds getter for general tag for the purpose of visualizing `road_border`.

<img width="1169" height="1333" alt="image" src="https://github.com/user-attachments/assets/c8b52ef5-884e-447d-b50e-27e54d72cb8d" />

Note: `road_border` is the recommended boundary tag when creating map [ref](https://docs.pilot.auto/reference-design/common/map-requirements/vector-map-requirements/category_lane/#vm-01-15-%E8%B7%AF%E8%82%A9). Therefore it make sense to support the getter them.

## How was this PR tested?

Build success
visualize the border with https://github.com/autowarefoundation/autoware_core/pull/575

## Notes for reviewers

None.

## Effects on system behavior

None.
