### PR TITLE
feat: add roundabout regulatory element

### DIFF
--- a/autoware_lanelet2_extension/CMakeLists.txt
+++ b/autoware_lanelet2_extension/CMakeLists.txt
@@ -16,6 +16,7 @@ ament_auto_add_library(${PROJECT_NAME}_lib SHARED
   lib/message_conversion.cpp
   lib/mgrs_projector.cpp
   lib/query.cpp
+  lib/roundabout.cpp
   lib/road_marking.cpp
   lib/speed_bump.cpp
   lib/transverse_mercator_projector.cpp

--- a/autoware_lanelet2_extension/include/autoware_lanelet2_extension/regulatory_elements/roundabout.hpp
+++ b/autoware_lanelet2_extension/include/autoware_lanelet2_extension/regulatory_elements/roundabout.hpp
@@ -74,6 +74,16 @@ public:
    */
   [[nodiscard]] lanelet::ConstLanelets roundaboutInternalLanelets() const;
 
+  /**
+   * @brief Check if the given lanelet is an entry lanelet of this roundabout
+   */
+  bool isEntryLanelet(const lanelet::ConstLanelet & lanelet) const;
+
+  /**
+   * @brief Check if the given lanelet is an exit lanelet of this roundabout
+   */
+  bool isExitLanelet(const lanelet::ConstLanelet & lanelet) const;
+
 private:
   Roundabout(
     Id id, const AttributeMap & attributes, const lanelet::Lanelets & roundabout_entry_lanelets,

--- a/autoware_lanelet2_extension/include/autoware_lanelet2_extension/regulatory_elements/roundabout.hpp
+++ b/autoware_lanelet2_extension/include/autoware_lanelet2_extension/regulatory_elements/roundabout.hpp
@@ -1,0 +1,94 @@
+// Copyright 2023 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE_LANELET2_EXTENSION__REGULATORY_ELEMENTS__CROSSWALK_HPP_
+#define AUTOWARE_LANELET2_EXTENSION__REGULATORY_ELEMENTS__CROSSWALK_HPP_
+
+// NOLINTBEGIN(readability-identifier-naming)
+
+#include <autoware_lanelet2_extension/regulatory_elements/Forward.hpp>
+
+#include <lanelet2_core/primitives/Lanelet.h>
+
+#include <memory>
+#include <set>
+
+namespace lanelet::autoware
+{
+
+inline namespace format_v2
+{
+class Roundabout : public lanelet::RegulatoryElement
+{
+public:
+  using Ptr = std::shared_ptr<Roundabout>;
+  static constexpr char RuleName[] = "roundabout";
+
+  struct AutowareRoleNameString
+  {
+    static constexpr const char Entry[] = "entry";
+    static constexpr const char Exit[] = "exit";
+    static constexpr const char Internal[] = "internal";
+  };
+
+  static Ptr make(
+    Id id, const AttributeMap & attributes, const lanelet::Lanelets & roundabout_entry_lanelets,
+    const lanelet::Lanelets & roundabout_exit_lanelets,
+    const lanelet::Lanelets & roundabout_internal_lanelets)
+  {
+    return Ptr{new Roundabout(
+      id, attributes, roundabout_entry_lanelets, roundabout_exit_lanelets,
+      roundabout_internal_lanelets)};
+  }
+
+  /**
+   * @brief get the relevant roundabout lanelet
+   * @return lanelet
+   */
+  [[nodiscard]] lanelet::ConstLanelets roundaboutLanelets() const;
+  /**
+   * @brief get the relevant roundabout entry lanelet
+   * @return lanelets
+   */
+  [[nodiscard]] lanelet::ConstLanelets roundaboutEntryLanelets() const;
+
+  /**
+   * @brief get the relevant roundabout exit lanelet
+   * @return lanelets
+   */
+  [[nodiscard]] lanelet::ConstLanelets roundaboutExitLanelets() const;
+  /**
+   * @brief get the relevant roundabout internal lanelet
+   * @return lanelets
+   */
+  [[nodiscard]] lanelet::ConstLanelets roundaboutInternalLanelets() const;
+
+private:
+  Roundabout(
+    Id id, const AttributeMap & attributes, const lanelet::Lanelets & roundabout_entry_lanelets,
+    const lanelet::Lanelets & roundabout_exit_lanelets,
+    const lanelet::Lanelets & roundabout_internal_lanelets);
+
+  // the following lines are required so that lanelet2 can create this object
+  // when loading a map with this regulatory element
+  friend class RegisterRegulatoryElement<Roundabout>;
+  explicit Roundabout(const lanelet::RegulatoryElementDataPtr & data);
+};
+}  // namespace format_v2
+
+}  // namespace lanelet::autoware
+
+// NOLINTEND(readability-identifier-naming)
+
+#endif  // AUTOWARE_LANELET2_EXTENSION__REGULATORY_ELEMENTS__CROSSWALK_HPP_

--- a/autoware_lanelet2_extension/include/autoware_lanelet2_extension/regulatory_elements/roundabout.hpp
+++ b/autoware_lanelet2_extension/include/autoware_lanelet2_extension/regulatory_elements/roundabout.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE_LANELET2_EXTENSION__REGULATORY_ELEMENTS__CROSSWALK_HPP_
-#define AUTOWARE_LANELET2_EXTENSION__REGULATORY_ELEMENTS__CROSSWALK_HPP_
+#ifndef AUTOWARE_LANELET2_EXTENSION__REGULATORY_ELEMENTS__ROUNDABOUT_HPP_
+#define AUTOWARE_LANELET2_EXTENSION__REGULATORY_ELEMENTS__ROUNDABOUT_HPP_
 
 // NOLINTBEGIN(readability-identifier-naming)
 
@@ -22,7 +22,7 @@
 #include <lanelet2_core/primitives/Lanelet.h>
 
 #include <memory>
-#include <set>
+#include <unordered_set>
 
 namespace lanelet::autoware
 {
@@ -75,20 +75,40 @@ public:
   [[nodiscard]] lanelet::ConstLanelets roundaboutInternalLanelets() const;
 
   /**
-   * @brief Check if the given lanelet is an entry lanelet of this roundabout
+   * @brief Check if the given lanelet is an entry lanelet
+   * @return true if the lanelet is an entry lanelet, false otherwise
    */
-  bool isEntryLanelet(const lanelet::ConstLanelet & lanelet) const;
+  [[nodiscard]] bool isEntryLanelet(const lanelet::ConstLanelet & lanelet) const;
 
   /**
-   * @brief Check if the given lanelet is an exit lanelet of this roundabout
+   * @brief Check if the given lanelet is an internal lanelet
+   * @return true if the lanelet is an internal lanelet, false otherwise
    */
-  bool isExitLanelet(const lanelet::ConstLanelet & lanelet) const;
+  [[nodiscard]] bool isInternalLanelet(const lanelet::ConstLanelet & lanelet) const;
+
+  /**
+   * @brief Check if the given lanelet is an exit lanelet
+   * @return true if the lanelet is an exit lanelet, false otherwise
+   */
+  [[nodiscard]] bool isExitLanelet(const lanelet::ConstLanelet & lanelet) const;
+
+  /**
+   * @brief Check if the given lanelet is a roundabout lanelet
+   * @return true if the lanelet is a roundabout lanelet, false otherwise
+   */
+  [[nodiscard]] bool isRoundaboutLanelet(const lanelet::ConstLanelet & lanelet) const;
 
 private:
   Roundabout(
     Id id, const AttributeMap & attributes, const lanelet::Lanelets & roundabout_entry_lanelets,
     const lanelet::Lanelets & roundabout_exit_lanelets,
     const lanelet::Lanelets & roundabout_internal_lanelets);
+
+  void cacheLaneletIds();  // IDをキャッシュするヘルパー関数
+
+  std::unordered_set<lanelet::Id> entry_lanelet_ids_;
+  std::unordered_set<lanelet::Id> exit_lanelet_ids_;
+  std::unordered_set<lanelet::Id> internal_lanelet_ids_;
 
   // the following lines are required so that lanelet2 can create this object
   // when loading a map with this regulatory element
@@ -101,4 +121,4 @@ private:
 
 // NOLINTEND(readability-identifier-naming)
 
-#endif  // AUTOWARE_LANELET2_EXTENSION__REGULATORY_ELEMENTS__CROSSWALK_HPP_
+#endif  // AUTOWARE_LANELET2_EXTENSION__REGULATORY_ELEMENTS__ROUNDABOUT_HPP_

--- a/autoware_lanelet2_extension/include/autoware_lanelet2_extension/regulatory_elements/roundabout.hpp
+++ b/autoware_lanelet2_extension/include/autoware_lanelet2_extension/regulatory_elements/roundabout.hpp
@@ -78,25 +78,25 @@ public:
    * @brief Check if the given lanelet is an entry lanelet
    * @return true if the lanelet is an entry lanelet, false otherwise
    */
-  [[nodiscard]] bool isEntryLanelet(const lanelet::ConstLanelet & lanelet) const;
+  [[nodiscard]] bool isEntryLanelet(const lanelet::Id & lanelet_id) const;
 
   /**
    * @brief Check if the given lanelet is an internal lanelet
    * @return true if the lanelet is an internal lanelet, false otherwise
    */
-  [[nodiscard]] bool isInternalLanelet(const lanelet::ConstLanelet & lanelet) const;
+  [[nodiscard]] bool isInternalLanelet(const lanelet::Id & lanelet_id) const;
 
   /**
    * @brief Check if the given lanelet is an exit lanelet
    * @return true if the lanelet is an exit lanelet, false otherwise
    */
-  [[nodiscard]] bool isExitLanelet(const lanelet::ConstLanelet & lanelet) const;
+  [[nodiscard]] bool isExitLanelet(const lanelet::Id & lanelet_id) const;
 
   /**
    * @brief Check if the given lanelet is a roundabout lanelet
    * @return true if the lanelet is a roundabout lanelet, false otherwise
    */
-  [[nodiscard]] bool isRoundaboutLanelet(const lanelet::ConstLanelet & lanelet) const;
+  [[nodiscard]] bool isRoundaboutLanelet(const lanelet::Id & lanelet_id) const;
 
 private:
   Roundabout(
@@ -104,7 +104,7 @@ private:
     const lanelet::Lanelets & roundabout_exit_lanelets,
     const lanelet::Lanelets & roundabout_internal_lanelets);
 
-  void cacheLaneletIds();  // IDをキャッシュするヘルパー関数
+  void cacheLaneletIds();  
 
   std::unordered_set<lanelet::Id> entry_lanelet_ids_;
   std::unordered_set<lanelet::Id> exit_lanelet_ids_;

--- a/autoware_lanelet2_extension/include/autoware_lanelet2_extension/regulatory_elements/roundabout.hpp
+++ b/autoware_lanelet2_extension/include/autoware_lanelet2_extension/regulatory_elements/roundabout.hpp
@@ -104,7 +104,7 @@ private:
     const lanelet::Lanelets & roundabout_exit_lanelets,
     const lanelet::Lanelets & roundabout_internal_lanelets);
 
-  void cacheLaneletIds();  
+  void cacheLaneletIds();
 
   std::unordered_set<lanelet::Id> entry_lanelet_ids_;
   std::unordered_set<lanelet::Id> exit_lanelet_ids_;

--- a/autoware_lanelet2_extension/lib/roundabout.cpp
+++ b/autoware_lanelet2_extension/lib/roundabout.cpp
@@ -20,8 +20,6 @@
 
 #include <lanelet2_core/primitives/RegulatoryElement.h>
 
-#include <algorithm>
-#include <iostream>
 #include <memory>
 #include <unordered_set>
 #include <utility>

--- a/autoware_lanelet2_extension/lib/roundabout.cpp
+++ b/autoware_lanelet2_extension/lib/roundabout.cpp
@@ -23,9 +23,9 @@
 #include <algorithm>
 #include <iostream>
 #include <memory>
+#include <unordered_set>
 #include <utility>
 #include <vector>
-#include <unordered_set>
 
 namespace lanelet::autoware
 {

--- a/autoware_lanelet2_extension/lib/roundabout.cpp
+++ b/autoware_lanelet2_extension/lib/roundabout.cpp
@@ -30,29 +30,6 @@ namespace lanelet::autoware
 {
 namespace
 {
-template <typename T>
-bool findAndErase(const T & primitive, RuleParameters * member)
-{
-  if (member == nullptr) {
-    std::cerr << __FUNCTION__ << ": member is null pointer";
-    return false;
-  }
-  auto it = std::find(member->begin(), member->end(), RuleParameter(primitive));
-  if (it == member->end()) {
-    return false;
-  }
-  member->erase(it);
-  return true;
-}
-
-template <typename T>
-Optional<T> tryGetFront(const std::vector<T> & vec)
-{
-  if (vec.empty()) {
-    return {};
-  }
-  return vec.front();
-}
 
 template <typename T>
 RuleParameters toRuleParameters(const std::vector<T> & primitives)
@@ -151,24 +128,24 @@ void Roundabout::cacheLaneletIds()
   internal_lanelet_ids_ = cache(roundaboutInternalLanelets());
 }
 
-bool Roundabout::isEntryLanelet(const lanelet::ConstLanelet & lanelet) const
+bool Roundabout::isEntryLanelet(const lanelet::Id & lanelet_id) const
 {
-  return entry_lanelet_ids_.count(lanelet.id()) > 0;
+  return entry_lanelet_ids_.find(lanelet_id) != entry_lanelet_ids_.end();
 }
 
-bool Roundabout::isInternalLanelet(const lanelet::ConstLanelet & lanelet) const
+bool Roundabout::isInternalLanelet(const lanelet::Id & lanelet_id) const
 {
-  return internal_lanelet_ids_.count(lanelet.id()) > 0;
+  return internal_lanelet_ids_.find(lanelet_id) != internal_lanelet_ids_.end();
 }
 
-bool Roundabout::isExitLanelet(const lanelet::ConstLanelet & lanelet) const
+bool Roundabout::isExitLanelet(const lanelet::Id & lanelet_id) const
 {
-  return exit_lanelet_ids_.count(lanelet.id()) > 0;
+  return exit_lanelet_ids_.find(lanelet_id) != exit_lanelet_ids_.end();
 }
 
-bool Roundabout::isRoundaboutLanelet(const lanelet::ConstLanelet & lanelet) const
+bool Roundabout::isRoundaboutLanelet(const lanelet::Id & lanelet_id) const
 {
-  return isEntryLanelet(lanelet) || isExitLanelet(lanelet) || isInternalLanelet(lanelet);
+  return isEntryLanelet(lanelet_id) || isExitLanelet(lanelet_id) || isInternalLanelet(lanelet_id);
 }
 
 RegisterRegulatoryElement<Roundabout> regRoundabout;

--- a/autoware_lanelet2_extension/lib/roundabout.cpp
+++ b/autoware_lanelet2_extension/lib/roundabout.cpp
@@ -68,19 +68,19 @@ RegulatoryElementDataPtr constructRoundabout(
 {
   RuleParameterMap rpm;
 
-for (const auto & entry : roundabout_entry_lanelets) {
-  RuleParameters rule_parameters = {RuleParameter(entry)};
-  rpm.insert(std::make_pair(Roundabout::AutowareRoleNameString::Entry, rule_parameters));
-}
+  for (const auto & entry : roundabout_entry_lanelets) {
+    RuleParameters rule_parameters = {RuleParameter(entry)};
+    rpm.insert(std::make_pair(Roundabout::AutowareRoleNameString::Entry, rule_parameters));
+  }
 
-for (const auto & exit : roundabout_exit_lanelets) {
-  RuleParameters rule_parameters = {RuleParameter(exit)};
-  rpm.insert(std::make_pair(Roundabout::AutowareRoleNameString::Exit, rule_parameters));
-}
-for (const auto & internal : roundabout_internal_lanelets) {
-  RuleParameters rule_parameters = {RuleParameter(internal)};
-  rpm.insert(std::make_pair(Roundabout::AutowareRoleNameString::Internal, rule_parameters));
-}
+  for (const auto & exit : roundabout_exit_lanelets) {
+    RuleParameters rule_parameters = {RuleParameter(exit)};
+    rpm.insert(std::make_pair(Roundabout::AutowareRoleNameString::Exit, rule_parameters));
+  }
+  for (const auto & internal : roundabout_internal_lanelets) {
+    RuleParameters rule_parameters = {RuleParameter(internal)};
+    rpm.insert(std::make_pair(Roundabout::AutowareRoleNameString::Internal, rule_parameters));
+  }
   auto data = std::make_shared<RegulatoryElementData>(id, std::move(rpm), attributes);
   data->attributes[AttributeName::Type] = AttributeValueString::RegulatoryElement;
   data->attributes[AttributeName::Subtype] = "roundabout";
@@ -128,6 +128,20 @@ lanelet::ConstLanelets Roundabout::roundaboutExitLanelets() const
 lanelet::ConstLanelets Roundabout::roundaboutInternalLanelets() const
 {
   return getParameters<lanelet::ConstLanelet>(AutowareRoleNameString::Internal);
+}
+
+bool Roundabout::isEntryLanelet(const lanelet::ConstLanelet & lanelet) const
+{
+  const auto entries = roundaboutEntryLanelets();
+  return std::any_of(
+    entries.begin(), entries.end(), [&](const auto & l) { return l.id() == lanelet.id(); });
+}
+
+bool Roundabout::isExitLanelet(const lanelet::ConstLanelet & lanelet) const
+{
+  const auto exits = roundaboutExitLanelets();
+  return std::any_of(
+    exits.begin(), exits.end(), [&](const auto & l) { return l.id() == lanelet.id(); });
 }
 
 RegisterRegulatoryElement<Roundabout> regRoundabout;

--- a/autoware_lanelet2_extension/lib/roundabout.cpp
+++ b/autoware_lanelet2_extension/lib/roundabout.cpp
@@ -25,6 +25,7 @@
 #include <memory>
 #include <utility>
 #include <vector>
+#include <unordered_set>
 
 namespace lanelet::autoware
 {

--- a/autoware_lanelet2_extension/lib/roundabout.cpp
+++ b/autoware_lanelet2_extension/lib/roundabout.cpp
@@ -1,0 +1,137 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOLINTBEGIN(readability-identifier-naming)
+
+#include "autoware_lanelet2_extension/regulatory_elements/roundabout.hpp"
+
+#include <boost/variant.hpp>
+
+#include <lanelet2_core/primitives/RegulatoryElement.h>
+
+#include <algorithm>
+#include <iostream>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace lanelet::autoware
+{
+namespace
+{
+template <typename T>
+bool findAndErase(const T & primitive, RuleParameters * member)
+{
+  if (member == nullptr) {
+    std::cerr << __FUNCTION__ << ": member is null pointer";
+    return false;
+  }
+  auto it = std::find(member->begin(), member->end(), RuleParameter(primitive));
+  if (it == member->end()) {
+    return false;
+  }
+  member->erase(it);
+  return true;
+}
+
+template <typename T>
+Optional<T> tryGetFront(const std::vector<T> & vec)
+{
+  if (vec.empty()) {
+    return {};
+  }
+  return vec.front();
+}
+
+template <typename T>
+RuleParameters toRuleParameters(const std::vector<T> & primitives)
+{
+  auto cast_func = [](const auto & elem) { return static_cast<RuleParameter>(elem); };
+  return utils::transform(primitives, cast_func);
+}
+
+RegulatoryElementDataPtr constructRoundabout(
+  Id id, const AttributeMap & attributes, const lanelet::Lanelets & roundabout_entry_lanelets,
+  const lanelet::Lanelets & roundabout_exit_lanelets,
+  const lanelet::Lanelets & roundabout_internal_lanelets)
+{
+  RuleParameterMap rpm;
+
+for (const auto & entry : roundabout_entry_lanelets) {
+  RuleParameters rule_parameters = {RuleParameter(entry)};
+  rpm.insert(std::make_pair(Roundabout::AutowareRoleNameString::Entry, rule_parameters));
+}
+
+for (const auto & exit : roundabout_exit_lanelets) {
+  RuleParameters rule_parameters = {RuleParameter(exit)};
+  rpm.insert(std::make_pair(Roundabout::AutowareRoleNameString::Exit, rule_parameters));
+}
+for (const auto & internal : roundabout_internal_lanelets) {
+  RuleParameters rule_parameters = {RuleParameter(internal)};
+  rpm.insert(std::make_pair(Roundabout::AutowareRoleNameString::Internal, rule_parameters));
+}
+  auto data = std::make_shared<RegulatoryElementData>(id, std::move(rpm), attributes);
+  data->attributes[AttributeName::Type] = AttributeValueString::RegulatoryElement;
+  data->attributes[AttributeName::Subtype] = "roundabout";
+  return data;
+}
+}  // namespace
+
+Roundabout::Roundabout(const RegulatoryElementDataPtr & data) : RegulatoryElement(data)
+{
+}
+
+Roundabout::Roundabout(
+  Id id, const AttributeMap & attributes, const lanelet::Lanelets & roundabout_entry_lanelets,
+  const lanelet::Lanelets & roundabout_exit_lanelets,
+  const lanelet::Lanelets & roundabout_internal_lanelets)
+: Roundabout(constructRoundabout(
+    id, attributes, roundabout_entry_lanelets, roundabout_exit_lanelets,
+    roundabout_internal_lanelets))
+{
+}
+
+lanelet::ConstLanelets Roundabout::roundaboutLanelets() const
+{
+  lanelet::ConstLanelets lanelets;
+  auto entry_lanelets = getParameters<lanelet::ConstLanelet>(AutowareRoleNameString::Entry);
+  auto exit_lanelets = getParameters<lanelet::ConstLanelet>(AutowareRoleNameString::Exit);
+  auto internal_lanelets = getParameters<lanelet::ConstLanelet>(AutowareRoleNameString::Internal);
+
+  lanelets.insert(lanelets.end(), entry_lanelets.begin(), entry_lanelets.end());
+  lanelets.insert(lanelets.end(), exit_lanelets.begin(), exit_lanelets.end());
+  lanelets.insert(lanelets.end(), internal_lanelets.begin(), internal_lanelets.end());
+
+  return lanelets;
+}
+
+lanelet::ConstLanelets Roundabout::roundaboutEntryLanelets() const
+{
+  return getParameters<lanelet::ConstLanelet>(AutowareRoleNameString::Entry);
+}
+
+lanelet::ConstLanelets Roundabout::roundaboutExitLanelets() const
+{
+  return getParameters<lanelet::ConstLanelet>(AutowareRoleNameString::Exit);
+}
+lanelet::ConstLanelets Roundabout::roundaboutInternalLanelets() const
+{
+  return getParameters<lanelet::ConstLanelet>(AutowareRoleNameString::Internal);
+}
+
+RegisterRegulatoryElement<Roundabout> regRoundabout;
+
+}  // namespace lanelet::autoware
+
+// NOLINTEND(readability-identifier-naming)

--- a/autoware_lanelet2_extension/test/src/test_regulatory_elements.cpp
+++ b/autoware_lanelet2_extension/test/src/test_regulatory_elements.cpp
@@ -188,8 +188,7 @@ TEST(TestSuite, RoundaboutInstantiation)  // NOLINT for gtest
 
   lanelet::Lanelets roundabout_entry_lanelets = {
     roundabout_entry_lanelet1, roundabout_entry_lanelet2};
-  lanelet::Lanelets roundabout_exit_lanelets = {
-    roundabout_exit_lanelet1, roundabout_exit_lanelet2};
+  lanelet::Lanelets roundabout_exit_lanelets = {roundabout_exit_lanelet1, roundabout_exit_lanelet2};
   lanelet::Lanelets roundabout_internal_lanelets = {
     roundabout_internal_lanelet1, roundabout_internal_lanelet2};
   // create roundabout
@@ -197,9 +196,11 @@ TEST(TestSuite, RoundaboutInstantiation)  // NOLINT for gtest
     getId(), lanelet::AttributeMap{}, roundabout_entry_lanelets, roundabout_exit_lanelets,
     roundabout_internal_lanelets);
   EXPECT_EQ(roundabout_reg_elem->roundaboutLanelets().size(), 6);
-  EXPECT_EQ(roundabout_reg_elem->roundaboutEntryLanelets().size(), roundabout_entry_lanelets.size());
+  EXPECT_EQ(
+    roundabout_reg_elem->roundaboutEntryLanelets().size(), roundabout_entry_lanelets.size());
   EXPECT_EQ(roundabout_reg_elem->roundaboutExitLanelets().size(), roundabout_exit_lanelets.size());
-  EXPECT_EQ(roundabout_reg_elem->roundaboutInternalLanelets().size(), roundabout_internal_lanelets.size());
+  EXPECT_EQ(
+    roundabout_reg_elem->roundaboutInternalLanelets().size(), roundabout_internal_lanelets.size());
   EXPECT_TRUE(roundabout_reg_elem->isEntryLanelet(roundabout_entry_lanelet1.id()));
   EXPECT_TRUE(roundabout_reg_elem->isEntryLanelet(roundabout_entry_lanelet2.id()));
   EXPECT_FALSE(roundabout_reg_elem->isEntryLanelet(roundabout_exit_lanelet1.id()));
@@ -224,7 +225,6 @@ TEST(TestSuite, RoundaboutInstantiation)  // NOLINT for gtest
   EXPECT_FALSE(roundabout_reg_elem->isInternalLanelet(roundabout_exit_lanelet3.id()));
   EXPECT_TRUE(roundabout_reg_elem->isRoundaboutLanelet(roundabout_entry_lanelet1.id()));
   EXPECT_FALSE(roundabout_reg_elem->isRoundaboutLanelet(roundabout_exit_lanelet3.id()));
-
 }
 
 // NOLINTEND(readability-identifier-naming)

--- a/autoware_lanelet2_extension/test/src/test_regulatory_elements.cpp
+++ b/autoware_lanelet2_extension/test/src/test_regulatory_elements.cpp
@@ -16,6 +16,7 @@
 
 #include "autoware_lanelet2_extension/regulatory_elements/autoware_traffic_light.hpp"
 #include "autoware_lanelet2_extension/regulatory_elements/bus_stop_area.hpp"
+#include "autoware_lanelet2_extension/regulatory_elements/roundabout.hpp"
 
 #include <boost/optional/optional_io.hpp>
 
@@ -165,6 +166,65 @@ int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
+}
+
+TEST(TestSuite, RoundaboutInstantiation)  // NOLINT for gtest
+{
+  // create sample lanelets
+  const Point3d p1(getId(), 0.0, 0.0, 0.0);
+  const Point3d p2(getId(), 0.0, 1.0, 0.0);
+  const LineString3d ls_left(getId(), {p1, p2});
+  const Point3d p3(getId(), 1.0, 0.0, 0.0);
+  const Point3d p4(getId(), 1.0, 0.0, 0.0);
+  const LineString3d ls_right(getId(), {p3, p4});
+
+  lanelet::Lanelet roundabout_entry_lanelet1(getId(), ls_left, ls_right);
+  lanelet::Lanelet roundabout_entry_lanelet2(getId(), ls_left, ls_right);
+  lanelet::Lanelet roundabout_exit_lanelet1(getId(), ls_left, ls_right);
+  lanelet::Lanelet roundabout_exit_lanelet2(getId(), ls_left, ls_right);
+  lanelet::Lanelet roundabout_exit_lanelet3(getId(), ls_left, ls_right);
+  lanelet::Lanelet roundabout_internal_lanelet1(getId(), ls_left, ls_right);
+  lanelet::Lanelet roundabout_internal_lanelet2(getId(), ls_left, ls_right);
+
+  lanelet::Lanelets roundabout_entry_lanelets = {
+    roundabout_entry_lanelet1, roundabout_entry_lanelet2};
+  lanelet::Lanelets roundabout_exit_lanelets = {
+    roundabout_exit_lanelet1, roundabout_exit_lanelet2};
+  lanelet::Lanelets roundabout_internal_lanelets = {
+    roundabout_internal_lanelet1, roundabout_internal_lanelet2};
+  // create roundabout
+  auto roundabout_reg_elem = lanelet::autoware::Roundabout::make(
+    getId(), lanelet::AttributeMap{}, roundabout_entry_lanelets, roundabout_exit_lanelets,
+    roundabout_internal_lanelets);
+  EXPECT_EQ(roundabout_reg_elem->roundaboutLanelets().size(), 6);
+  EXPECT_EQ(roundabout_reg_elem->roundaboutEntryLanelets().size(), roundabout_entry_lanelets.size());
+  EXPECT_EQ(roundabout_reg_elem->roundaboutExitLanelets().size(), roundabout_exit_lanelets.size());
+  EXPECT_EQ(roundabout_reg_elem->roundaboutInternalLanelets().size(), roundabout_internal_lanelets.size());
+  EXPECT_TRUE(roundabout_reg_elem->isEntryLanelet(roundabout_entry_lanelet1.id()));
+  EXPECT_TRUE(roundabout_reg_elem->isEntryLanelet(roundabout_entry_lanelet2.id()));
+  EXPECT_FALSE(roundabout_reg_elem->isEntryLanelet(roundabout_exit_lanelet1.id()));
+  EXPECT_FALSE(roundabout_reg_elem->isEntryLanelet(roundabout_exit_lanelet2.id()));
+  EXPECT_FALSE(roundabout_reg_elem->isEntryLanelet(roundabout_exit_lanelet3.id()));
+  EXPECT_FALSE(roundabout_reg_elem->isEntryLanelet(roundabout_internal_lanelet1.id()));
+  EXPECT_FALSE(roundabout_reg_elem->isEntryLanelet(roundabout_internal_lanelet2.id()));
+  EXPECT_TRUE(roundabout_reg_elem->isExitLanelet(roundabout_exit_lanelet1.id()));
+  EXPECT_TRUE(roundabout_reg_elem->isExitLanelet(roundabout_exit_lanelet2.id()));
+  EXPECT_FALSE(roundabout_reg_elem->isExitLanelet(roundabout_exit_lanelet3.id()));
+  EXPECT_FALSE(roundabout_reg_elem->isExitLanelet(roundabout_entry_lanelet1.id()));
+  EXPECT_FALSE(roundabout_reg_elem->isExitLanelet(roundabout_entry_lanelet2.id()));
+  EXPECT_FALSE(roundabout_reg_elem->isExitLanelet(roundabout_internal_lanelet1.id()));
+  EXPECT_FALSE(roundabout_reg_elem->isExitLanelet(roundabout_internal_lanelet2.id()));
+  EXPECT_TRUE(roundabout_reg_elem->isInternalLanelet(roundabout_internal_lanelet1.id()));
+  EXPECT_TRUE(roundabout_reg_elem->isInternalLanelet(roundabout_internal_lanelet2.id()));
+  EXPECT_FALSE(roundabout_reg_elem->isInternalLanelet(roundabout_exit_lanelet3.id()));
+  EXPECT_FALSE(roundabout_reg_elem->isInternalLanelet(roundabout_entry_lanelet1.id()));
+  EXPECT_FALSE(roundabout_reg_elem->isInternalLanelet(roundabout_entry_lanelet2.id()));
+  EXPECT_FALSE(roundabout_reg_elem->isInternalLanelet(roundabout_exit_lanelet1.id()));
+  EXPECT_FALSE(roundabout_reg_elem->isInternalLanelet(roundabout_exit_lanelet2.id()));
+  EXPECT_FALSE(roundabout_reg_elem->isInternalLanelet(roundabout_exit_lanelet3.id()));
+  EXPECT_TRUE(roundabout_reg_elem->isRoundaboutLanelet(roundabout_entry_lanelet1.id()));
+  EXPECT_FALSE(roundabout_reg_elem->isRoundaboutLanelet(roundabout_exit_lanelet3.id()));
+
 }
 
 // NOLINTEND(readability-identifier-naming)


### PR DESCRIPTION
## Description
This PR adds a roundabout regulatory element.

example:
```
  <relation id='1001' visible='true' version='1'>
    <member type='relation' ref='1' role='entry' /> <!-- points to entry lanelets -->
    <member type='relation' ref='2' role='entry' />
    <member type='relation' ref='3' role='internal' />
    <member type='relation' ref='4' role='exit' />
    <member type='relation' ref='5' role='exit' />
    <tag k='subtype' v='roundabout' />
    <tag k='type' v='regulatory_element' />
  </relation>
```
Related universe PR: https://github.com/autowarefoundation/autoware_universe/pull/10944
Related discussion: https://github.com/orgs/autowarefoundation/discussions/6324#discussioncomment-13850712

## How was this PR tested?
tested with the map that has roundabout regulatory element

## Notes for reviewers
This PR should be merged before 
https://github.com/autowarefoundation/autoware_universe/pull/10944

## Effects on system behavior

None.
