### PR TITLE
chore: add build option -Wno-error=maybe-uninitialized

### DIFF
--- a/autoware_lanelet2_extension/CMakeLists.txt
+++ b/autoware_lanelet2_extension/CMakeLists.txt
@@ -26,6 +26,15 @@ ament_auto_add_library(${PROJECT_NAME}_lib SHARED
   lib/route_checker.cpp
 )
 
+# Suppress boost geometry uninitialized variable warnings
+# This is a known issue in boost geometry library where internal template code
+# may trigger maybe-uninitialized warnings that are false positives.
+# The warnings occur in boost geometry's distance calculation algorithms
+# and do not affect the actual functionality of the code.
+# Related: https://www.boost.org/doc/libs/latest/libs/utility/doc/html/utility/utilities/value_init.html
+# and https://www.boost.org/doc/libs/1_89_0/libs/optional/doc/html/boost_optional/design/gotchas/false_positive_with__wmaybe_uninitialized.html
+target_compile_options(${PROJECT_NAME}_lib PRIVATE -Wno-error=maybe-uninitialized)
+
 ament_auto_add_executable(${PROJECT_NAME}_sample src/sample_code.cpp)
 target_link_libraries(${PROJECT_NAME}_sample
   ${PROJECT_NAME}_lib


### PR DESCRIPTION
## Description
in order to solve compile error caused by using library boost-geometry

<img width="1729" height="385" alt="图片" src="https://github.com/user-attachments/assets/b371fcdc-ee94-412f-9fb9-c12ad1608b04" />

add build option `-Wno-error=maybe-uninitialized` to cmakelist.txt , it is recommended by boost official articles -- https://www.boost.org/doc/libs/1_89_0/libs/optional/doc/html/boost_optional/design/gotchas/false_positive_with__wmaybe_uninitialized.html

parent issue link -- https://github.com/autowarefoundation/autoware_core/issues/623

## How was this PR tested?

test with docker file produce by pr in autoware -- https://github.com/autowarefoundation/autoware/pull/6453
build command
colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS='-Wno-error=array-bounds -Wno-error=unused-but-set-variable -Wno-error=unused-variable -Wno-error=unused-function' --symlink-install --packages-up-to autoware_core

## Notes for reviewers

None.

## Effects on system behavior

None.
