### PR TITLE
feat: add traffic rules to enable driving for areas

### DIFF
--- a/autoware_lanelet2_extension/CMakeLists.txt
+++ b/autoware_lanelet2_extension/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(tf2 REQUIRED)
 autoware_package()
 
 ament_auto_add_library(${PROJECT_NAME}_lib SHARED
+  lib/autoware_traffic_rules.cpp
   lib/autoware_osm_parser.cpp
   lib/autoware_traffic_light.cpp
   lib/crosswalk.cpp

--- a/autoware_lanelet2_extension/include/autoware_lanelet2_extension/traffic_rules/autoware_traffic_rules.hpp
+++ b/autoware_lanelet2_extension/include/autoware_lanelet2_extension/traffic_rules/autoware_traffic_rules.hpp
@@ -1,0 +1,44 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE_LANELET2_EXTENSION__TRAFFIC_RULES__AUTOWARE_TRAFFIC_RULES_HPP_
+#define AUTOWARE_LANELET2_EXTENSION__TRAFFIC_RULES__AUTOWARE_TRAFFIC_RULES_HPP_
+
+#include <lanelet2_traffic_rules/GermanTrafficRules.h>
+#include <lanelet2_traffic_rules/TrafficRulesFactory.h>
+
+namespace lanelet::autoware
+{
+
+/// @brief Autoware-specific location identifier for traffic rules registration.
+static constexpr const char DefaultLocation[] = "autoware";
+
+/// @brief Vehicle traffic rules for Autoware based on GermanVehicle, but allowing areas in normal
+/// driving mode. GermanVehicle unconditionally disallows canPass(ConstArea), which prevents routing
+/// through areas. This class restores the GenericTrafficRules behavior that checks participant tags.
+class AutowareVehicle : public traffic_rules::GermanVehicle
+{
+public:
+  using GermanVehicle::GermanVehicle;
+
+  // Allow passing through areas based on participant tags (GenericTrafficRules default behavior)
+  bool canPass(const ConstArea & area) const override
+  {
+    return GenericTrafficRules::canPass(area);
+  }
+};
+
+}  // namespace lanelet::autoware
+
+#endif  // AUTOWARE_LANELET2_EXTENSION__TRAFFIC_RULES__AUTOWARE_TRAFFIC_RULES_HPP_

--- a/autoware_lanelet2_extension/include/autoware_lanelet2_extension/traffic_rules/autoware_traffic_rules.hpp
+++ b/autoware_lanelet2_extension/include/autoware_lanelet2_extension/traffic_rules/autoware_traffic_rules.hpp
@@ -26,17 +26,15 @@ static constexpr const char DefaultLocation[] = "autoware";
 
 /// @brief Vehicle traffic rules for Autoware based on GermanVehicle, but allowing areas in normal
 /// driving mode. GermanVehicle unconditionally disallows canPass(ConstArea), which prevents routing
-/// through areas. This class restores the GenericTrafficRules behavior that checks participant tags.
+/// through areas. This class restores the GenericTrafficRules behavior that checks participant
+/// tags.
 class AutowareVehicle : public traffic_rules::GermanVehicle
 {
 public:
   using GermanVehicle::GermanVehicle;
 
   // Allow passing through areas based on participant tags (GenericTrafficRules default behavior)
-  bool canPass(const ConstArea & area) const override
-  {
-    return GenericTrafficRules::canPass(area);
-  }
+  bool canPass(const ConstArea & area) const override { return GenericTrafficRules::canPass(area); }
 };
 
 }  // namespace lanelet::autoware

--- a/autoware_lanelet2_extension/include/autoware_lanelet2_extension/utility/route_checker.hpp
+++ b/autoware_lanelet2_extension/include/autoware_lanelet2_extension/utility/route_checker.hpp
@@ -27,7 +27,9 @@ using autoware_planning_msgs::msg::LaneletRoute;
 
 /// @param allow_area If false, routes containing any primitive with primitive_type "area" are
 /// invalid (lane-only validation). If true, area ids are resolved on areaLayer.
-bool isRouteValid(const LaneletRoute & route, const lanelet::LaneletMapPtr lanelet_map_ptr_, bool allow_area = false);
+bool isRouteValid(
+  const LaneletRoute & route, const lanelet::LaneletMapPtr lanelet_map_ptr_,
+  bool allow_area = false);
 }  // namespace lanelet::utils::route
 
 // NOLINTEND(readability-identifier-naming)

--- a/autoware_lanelet2_extension/include/autoware_lanelet2_extension/utility/route_checker.hpp
+++ b/autoware_lanelet2_extension/include/autoware_lanelet2_extension/utility/route_checker.hpp
@@ -25,7 +25,9 @@ namespace lanelet::utils::route
 {
 using autoware_planning_msgs::msg::LaneletRoute;
 
-bool isRouteValid(const LaneletRoute & route, const lanelet::LaneletMapPtr lanelet_map_ptr_);
+/// @param allow_area If false, routes containing any primitive with primitive_type "area" are
+/// invalid (lane-only validation). If true, area ids are resolved on areaLayer.
+bool isRouteValid(const LaneletRoute & route, const lanelet::LaneletMapPtr lanelet_map_ptr_, bool allow_area = false);
 }  // namespace lanelet::utils::route
 
 // NOLINTEND(readability-identifier-naming)

--- a/autoware_lanelet2_extension/include/autoware_lanelet2_extension/visualization/visualization.hpp
+++ b/autoware_lanelet2_extension/include/autoware_lanelet2_extension/visualization/visualization.hpp
@@ -31,6 +31,7 @@
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/primitives/Area.h>
 #include <lanelet2_core/primitives/Lanelet.h>
 
 #include <string>
@@ -236,6 +237,17 @@ visualization_msgs::msg::MarkerArray hatchedRoadMarkingsAreaAsMarkerArray(
  */
 visualization_msgs::msg::MarkerArray obstacleRemovalAreaAsMarkerArray(
   const lanelet::ConstPolygons3d & obstacle_removal_area, const std_msgs::msg::ColorRGBA & c);
+
+/**
+ * [laneletAreasAsMarkerArray creates marker array to visualize Lanelet2 Area layer primitives
+ * (e.g. routing through lane-area-lane connections).]
+ * @param areas         [Lanelet2 ConstArea from map areaLayer]
+ * @param fill_color    [TRIANGLE_LIST fill color; namespace lanelet_routing_area]
+ * @param outline_color [LINE_STRIP boundary color; namespace lanelet_routing_area_outline]
+ */
+visualization_msgs::msg::MarkerArray laneletAreasAsMarkerArray(
+  const std::vector<lanelet::ConstArea> & areas, const std_msgs::msg::ColorRGBA & fill_color,
+  const std_msgs::msg::ColorRGBA & outline_color);
 }  // namespace format_v2
 
 /**

--- a/autoware_lanelet2_extension/lib/autoware_traffic_rules.cpp
+++ b/autoware_lanelet2_extension/lib/autoware_traffic_rules.cpp
@@ -18,6 +18,7 @@ namespace lanelet::autoware
 {
 
 // Register AutowareVehicle for the Autoware location + Vehicle participant.
-static traffic_rules::RegisterTrafficRules<AutowareVehicle> reg(DefaultLocation, Participants::Vehicle);
+static traffic_rules::RegisterTrafficRules<AutowareVehicle> reg(
+  DefaultLocation, Participants::Vehicle);
 
 }  // namespace lanelet::autoware

--- a/autoware_lanelet2_extension/lib/autoware_traffic_rules.cpp
+++ b/autoware_lanelet2_extension/lib/autoware_traffic_rules.cpp
@@ -1,0 +1,23 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware_lanelet2_extension/traffic_rules/autoware_traffic_rules.hpp"
+
+namespace lanelet::autoware
+{
+
+// Register AutowareVehicle for the Autoware location + Vehicle participant.
+static traffic_rules::RegisterTrafficRules<AutowareVehicle> reg(DefaultLocation, Participants::Vehicle);
+
+}  // namespace lanelet::autoware

--- a/autoware_lanelet2_extension/lib/route_checker.cpp
+++ b/autoware_lanelet2_extension/lib/route_checker.cpp
@@ -32,7 +32,11 @@ bool route::isRouteValid(
     for (const auto & primitive : route_section.primitives) {
       const auto id = primitive.id;
       try {
-        lanelet_map_ptr_->laneletLayer.get(id);
+        if (primitive.primitive_type == "area") {
+          lanelet_map_ptr_->areaLayer.get(id);
+        } else {
+          lanelet_map_ptr_->laneletLayer.get(id);
+        }
       } catch (const std::exception & e) {
         std::cerr
           << e.what()

--- a/autoware_lanelet2_extension/lib/route_checker.cpp
+++ b/autoware_lanelet2_extension/lib/route_checker.cpp
@@ -26,10 +26,14 @@
 namespace lanelet::utils
 {
 bool route::isRouteValid(
-  const LaneletRoute & route_msg, const lanelet::LaneletMapPtr lanelet_map_ptr_)
+  const LaneletRoute & route_msg, const lanelet::LaneletMapPtr lanelet_map_ptr_, bool allow_area)
 {
   for (const auto & route_section : route_msg.segments) {
     for (const auto & primitive : route_section.primitives) {
+      // If area is not allowed, and the primitive is an area, return false
+      if (primitive.primitive_type == "area" && !allow_area) {
+        return false;
+      }
       const auto id = primitive.id;
       try {
         if (primitive.primitive_type == "area") {

--- a/autoware_lanelet2_extension/lib/visualization.cpp
+++ b/autoware_lanelet2_extension/lib/visualization.cpp
@@ -34,9 +34,9 @@
 #include <cmath>
 #include <iostream>
 #include <string>
-#include <utility>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 namespace
@@ -398,15 +398,17 @@ bool areaOuterToPolygon3d(const lanelet::ConstArea & area, lanelet::Polygon3d * 
   llt_poly->clear();
   for (const auto & ls : area.outerBound()) {
     for (const auto & pt : ls) {
-      llt_poly->push_back(lanelet::Point3d(
-        lanelet::InvalId, pt.basicPoint().x(), pt.basicPoint().y(), pt.basicPoint().z()));
+      llt_poly->push_back(
+        lanelet::Point3d(
+          lanelet::InvalId, pt.basicPoint().x(), pt.basicPoint().y(), pt.basicPoint().z()));
     }
   }
   if (llt_poly->size() >= 2U) {
     const auto & f = llt_poly->front();
     const auto & b = llt_poly->back();
-    if (std::abs(f.basicPoint().x() - b.basicPoint().x()) < 1e-6 &&
-        std::abs(f.basicPoint().y() - b.basicPoint().y()) < 1e-6) {
+    if (
+      std::abs(f.basicPoint().x() - b.basicPoint().x()) < 1e-6 &&
+      std::abs(f.basicPoint().y() - b.basicPoint().y()) < 1e-6) {
       llt_poly->pop_back();
     }
   }
@@ -1276,7 +1278,8 @@ visualization_msgs::msg::MarkerArray laneletAreasAsMarkerArray(
     return marker_array;
   }
 
-  visualization_msgs::msg::Marker fill_marker = createPolygonMarker("lanelet_routing_area", fill_color);
+  visualization_msgs::msg::Marker fill_marker =
+    createPolygonMarker("lanelet_routing_area", fill_color);
   std::vector<visualization_msgs::msg::Marker> outline_markers;
   outline_markers.reserve(areas.size());
   int outline_id = 0;

--- a/autoware_lanelet2_extension/lib/visualization.cpp
+++ b/autoware_lanelet2_extension/lib/visualization.cpp
@@ -31,8 +31,10 @@
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <algorithm>
+#include <cmath>
 #include <iostream>
 #include <string>
+#include <utility>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -386,6 +388,60 @@ void pushPolygonMarker(
       marker->colors.push_back(color);
     }
   }
+}
+
+bool areaOuterToPolygon3d(const lanelet::ConstArea & area, lanelet::Polygon3d * llt_poly)
+{
+  if (llt_poly == nullptr) {
+    return false;
+  }
+  llt_poly->clear();
+  for (const auto & ls : area.outerBound()) {
+    for (const auto & pt : ls) {
+      llt_poly->push_back(lanelet::Point3d(
+        lanelet::InvalId, pt.basicPoint().x(), pt.basicPoint().y(), pt.basicPoint().z()));
+    }
+  }
+  if (llt_poly->size() >= 2U) {
+    const auto & f = llt_poly->front();
+    const auto & b = llt_poly->back();
+    if (std::abs(f.basicPoint().x() - b.basicPoint().x()) < 1e-6 &&
+        std::abs(f.basicPoint().y() - b.basicPoint().y()) < 1e-6) {
+      llt_poly->pop_back();
+    }
+  }
+  return llt_poly->size() >= 3U;
+}
+
+visualization_msgs::msg::Marker makeLaneletRoutingAreaOutlineMarker(
+  const int id, const lanelet::Polygon3d & poly, const std_msgs::msg::ColorRGBA & outline_color)
+{
+  visualization_msgs::msg::Marker line;
+  line.header.frame_id = "map";
+  line.header.stamp = rclcpp::Time();
+  line.ns = "lanelet_routing_area_outline";
+  line.id = id;
+  line.action = visualization_msgs::msg::Marker::ADD;
+  line.type = visualization_msgs::msg::Marker::LINE_STRIP;
+  line.scale.x = 0.05;
+  line.scale.y = 0.0;
+  line.scale.z = 0.0;
+  line.color = outline_color;
+  line.pose.orientation.w = 1.0;
+  line.lifetime = rclcpp::Duration(0, 0);
+  line.frame_locked = false;
+  line.points.reserve(poly.size() + 1U);
+  for (const auto & pt : poly) {
+    geometry_msgs::msg::Point p;
+    p.x = pt.x();
+    p.y = pt.y();
+    p.z = pt.z();
+    line.points.push_back(p);
+  }
+  if (!line.points.empty()) {
+    line.points.push_back(line.points.front());
+  }
+  return line;
 }
 
 }  // anonymous namespace
@@ -1207,6 +1263,39 @@ visualization_msgs::msg::MarkerArray obstacleRemovalAreaAsMarkerArray(
 
   if (!marker.points.empty()) {
     marker_array.markers.push_back(marker);
+  }
+  return marker_array;
+}
+
+visualization_msgs::msg::MarkerArray laneletAreasAsMarkerArray(
+  const std::vector<lanelet::ConstArea> & areas, const std_msgs::msg::ColorRGBA & fill_color,
+  const std_msgs::msg::ColorRGBA & outline_color)
+{
+  visualization_msgs::msg::MarkerArray marker_array;
+  if (areas.empty()) {
+    return marker_array;
+  }
+
+  visualization_msgs::msg::Marker fill_marker = createPolygonMarker("lanelet_routing_area", fill_color);
+  std::vector<visualization_msgs::msg::Marker> outline_markers;
+  outline_markers.reserve(areas.size());
+  int outline_id = 0;
+
+  for (const auto & area : areas) {
+    lanelet::Polygon3d llt_poly;
+    if (!areaOuterToPolygon3d(area, &llt_poly)) {
+      continue;
+    }
+    pushPolygonMarker(&fill_marker, llt_poly, fill_color);
+    outline_markers.push_back(
+      makeLaneletRoutingAreaOutlineMarker(outline_id++, llt_poly, outline_color));
+  }
+
+  if (!fill_marker.points.empty()) {
+    marker_array.markers.push_back(std::move(fill_marker));
+  }
+  for (auto & om : outline_markers) {
+    marker_array.markers.push_back(std::move(om));
   }
   return marker_array;
 }

--- a/autoware_lanelet2_extension/test/src/test_route_checker.cpp
+++ b/autoware_lanelet2_extension/test/src/test_route_checker.cpp
@@ -22,11 +22,14 @@
 
 #include <gtest/gtest.h>
 #include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/primitives/Area.h>
 
 #include <memory>
 
+using lanelet::Area;
 using lanelet::Lanelet;
 using lanelet::LineString3d;
+using lanelet::LineStrings3d;
 using lanelet::Point3d;
 using lanelet::utils::getId;
 
@@ -86,6 +89,60 @@ TEST_F(TestSuite, isRouteValid)  // NOLINT for gtest
   ASSERT_FALSE(lanelet::utils::route::isRouteValid(*route_ptr2, sample_map_ptr))
     << "The route should be invalid, which should be created on the different map from the current "
        "one";
+}
+
+TEST_F(TestSuite, isRouteValid_rejects_area_when_allow_area_false)  // NOLINT for gtest
+{
+  autoware_planning_msgs::msg::LaneletRoute route_with_area;
+  autoware_planning_msgs::msg::LaneletSegment segment;
+  autoware_planning_msgs::msg::LaneletPrimitive prim;
+  prim.primitive_type = "area";
+  prim.id = 99999;  // id is irrelevant when allow_area is false
+  segment.primitives.push_back(prim);
+  route_with_area.segments.push_back(segment);
+
+  ASSERT_FALSE(lanelet::utils::route::isRouteValid(route_with_area, sample_map_ptr, false))
+    << "Route with area primitive must be invalid when allow_area is false";
+  ASSERT_FALSE(lanelet::utils::route::isRouteValid(route_with_area, sample_map_ptr))
+    << "Default allow_area should be false for mixed routes";
+}
+
+TEST_F(TestSuite, isRouteValid_unknown_area_id_fails_when_allow_area_true)  // NOLINT for gtest
+{
+  autoware_planning_msgs::msg::LaneletRoute route_with_area;
+  autoware_planning_msgs::msg::LaneletSegment segment;
+  autoware_planning_msgs::msg::LaneletPrimitive prim;
+  prim.primitive_type = "area";
+  prim.id = 99999;  // not on map
+  segment.primitives.push_back(prim);
+  route_with_area.segments.push_back(segment);
+
+  ASSERT_FALSE(lanelet::utils::route::isRouteValid(route_with_area, sample_map_ptr, true))
+    << "Missing area id on map should fail validation";
+}
+
+TEST_F(TestSuite, isRouteValid_resolves_area_when_allow_area_true)  // NOLINT for gtest
+{
+  const lanelet::Id area_id = getId();
+  const Point3d a1(getId(), 10.0, 0.0, 0.0);
+  const Point3d a2(getId(), 12.0, 0.0, 0.0);
+  const Point3d a3(getId(), 12.0, 2.0, 0.0);
+  const Point3d a4(getId(), 10.0, 2.0, 0.0);
+  const LineString3d ring(getId(), {a1, a2, a3, a4, a1});
+  const LineStrings3d outer{ring};
+  const Area test_area(area_id, outer);
+  sample_map_ptr->add(test_area);
+
+  autoware_planning_msgs::msg::LaneletRoute route_with_area;
+  autoware_planning_msgs::msg::LaneletSegment segment;
+  autoware_planning_msgs::msg::LaneletPrimitive prim;
+  prim.primitive_type = "area";
+  prim.id = area_id;
+  segment.primitives.push_back(prim);
+  route_with_area.segments.push_back(segment);
+
+  ASSERT_TRUE(lanelet::utils::route::isRouteValid(route_with_area, sample_map_ptr, true))
+    << "Valid area id on map should pass when allow_area is true";
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION

## Description

- Enables **Lanelet2 routing / mission planning** to consider **paths that traverse lanelet → Area → lanelet** by extending **traffic rules** so **Areas can be treated as drivable** where appropriate.
- Adds **RViz visualization** for Lanelet2 **area layer**: filled polygon + outline markers (namespaces such as `lanelet_routing_area` / `lanelet_routing_area_outline`) so **multipolygon Areas** are easy to see on the map ([`14f99356`](https://github.com/emmeyteja/autoware_lanelet2_extension/commit/14f99356fc842ffb306a9347f9a8f4a286e77993)).

## How was this PR tested?

- `colcon build` / `colcon test` for `autoware_lanelet2_extension` (and packages that depend on it).
- Loaded a **Lanelet2 map** that includes **Area** relations and confirmed **shortest path including areas** is accepted when used together with matching **autoware_core** / **route_handler** changes (if this PR is paired with those).
- **RViz**: subscribed to lanelet map markers and confirmed **area fill + outline** render as expected.

## Notes for reviewers

- Visualization changes are largely in `visualization.cpp` (e.g. `areaOuterToPolygon3d`, `laneletAreasAsMarkerArray`); traffic-rule changes should be reviewed for **consistency with Lanelet2 `RoutingGraph::shortestPathIncludingAreas`** and existing rule sets.

## Related Links

**Related PRs**

- [autoware_core PR](https://github.com/autowarefoundation/autoware_core/pull/993)
- [autoware_universe PR](https://github.com/autowarefoundation/autoware_universe/pull/12381)

**Issues**
- TierIV Internal [Issue Link](https://tier4.atlassian.net/browse/T4DEV-51269) 

**Design Dcouments**

- Tier IV Internal [Design Document: Area Visualization](https://tier4.atlassian.net/wiki/spaces/SI/pages/5070815408/Detailed+Design+Document+Lanelet2+Routing+Area+Visualization+in+RViz)
- Tier IV Internal [Design Document: Route Serach through Areas](https://tier4.atlassian.net/wiki/spaces/SI/pages/5077074153/Detailed+Design+Document+Lanelet2+Area+Support+for+Route+Finding)

## Effects on system behavior

- **Routing**: With a compatible **route_handler** / map, routes may include **Area** segments instead of failing when the only feasible connection is **lanelet–area–lanelet**.
- **Visualization**: Maps with an **area layer** show **filled + outlined** area polygons in RViz (behavior for operators; default driving policy still depends on traffic rules + planner).
