### PR TITLE
chore(ci): update GitHub Actions runner to ubuntu-24.04

### DIFF
--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -21,7 +21,7 @@ jobs:
   build-and-test-differential:
     needs: make-sure-label-is-present
     if: ${{ needs.make-sure-label-is-present.outputs.result == 'true' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: ${{ matrix.container }}
     strategy:
       fail-fast: false

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   build-and-test:
     if: ${{ github.event_name != 'push' || github.ref_name == github.event.repository.default_branch }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: ${{ matrix.container }}
     strategy:
       fail-fast: false

--- a/.github/workflows/bump-new-version.yaml
+++ b/.github/workflows/bump-new-version.yaml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   update-versions:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate token
         id: generate-token

--- a/.github/workflows/cancel-previous-workflows.yaml
+++ b/.github/workflows/cancel-previous-workflows.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   cancel-previous-workflows:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.12.1

--- a/.github/workflows/comment-on-pr.yaml
+++ b/.github/workflows/comment-on-pr.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   comment-on-pr:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   github-release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Set tag name
         id: set-tag-name

--- a/.github/workflows/pre-commit-autoupdate.yaml
+++ b/.github/workflows/pre-commit-autoupdate.yaml
@@ -18,7 +18,7 @@ jobs:
   pre-commit-autoupdate:
     needs: check-secret
     if: ${{ needs.check-secret.outputs.set == 'true' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate token
         id: generate-token

--- a/.github/workflows/pre-commit-optional.yaml
+++ b/.github/workflows/pre-commit-optional.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   pre-commit-optional:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/release-new-version-when-merged.yaml
+++ b/.github/workflows/release-new-version-when-merged.yaml
@@ -12,7 +12,7 @@ jobs:
         join(github.event.pull_request.labels.*.name, ','),
         'release:bump-version'
       )
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate token
         id: generate-token

--- a/.github/workflows/spell-check-differential.yaml
+++ b/.github/workflows/spell-check-differential.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   spell-check-differential:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/sync-files.yaml
+++ b/.github/workflows/sync-files.yaml
@@ -18,7 +18,7 @@ jobs:
   sync-files:
     needs: check-secret
     if: ${{ needs.check-secret.outputs.set == 'true' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate token
         id: generate-token

--- a/.github/workflows/update-codeowners-from-packages.yaml
+++ b/.github/workflows/update-codeowners-from-packages.yaml
@@ -18,7 +18,7 @@ jobs:
   update-codeowners-from-packages:
     needs: check-secret
     if: ${{ needs.check-secret.outputs.set == 'true' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate token
         id: generate-token


### PR DESCRIPTION
## Summary
- Update GitHub Actions runner from `ubuntu-22.04` to `ubuntu-24.04`
- 12 workflow file(s) updated
- `ubuntu-22.04-m` and other variant runners are unchanged

## Test plan
- [ ] Verify CI workflows run successfully on `ubuntu-24.04`
